### PR TITLE
Small patch to made on_return running for own Screen's

### DIFF
--- a/lib/ProMotion/_screen_modules/screen_navigation.rb
+++ b/lib/ProMotion/_screen_modules/screen_navigation.rb
@@ -4,7 +4,7 @@ module ProMotion
       # Instantiate screen if given a class
       screen = screen.new if screen.respond_to?(:new)
 
-      if screen.is_a?(ProMotion::Screen) || screen.is_a?(ProMotion::TableScreen)
+      if screen.is_a?(ProMotion::Screen) || screen.is_a?(ProMotion::TableScreen) || screen.is_a?(ProMotion::ScreenModule)
         screen.parent_screen = self if screen.respond_to?("parent_screen=")
         screen.title = args[:title] if args[:title]
 


### PR DESCRIPTION
Without this patch a new abstract screen class (for example FormotionScreen) will not set the parent_screen.
