### PR TITLE
use module instead of class for ProMotion:Screen

### DIFF
--- a/lib/ProMotion/_screen_modules/screen_tabs.rb
+++ b/lib/ProMotion/_screen_modules/screen_tabs.rb
@@ -9,7 +9,7 @@ module ProMotion
       screens.map! { |s| s.respond_to?(:new) ? s.new : s } # Initialize any classes
 
       screens.each do |s|
-        if s.is_a?(ProMotion::Screen) || s.is_a?(ProMotion::TableScreen)
+        if s.is_a?(ProMotion::Screen) || s.is_a?(ProMotion::TableScreen) || s.is_a?(ProMotion::ScreenModule)
           s = s.new if s.respond_to?(:new)
           s.tabBarItem.tag = tag_index
           s.parent_screen = self if self.is_a?(UIViewController) && s.respond_to?("parent_screen=")


### PR DESCRIPTION
Same change as in screen now for screen_tab. Was using a inherited ProMotion::Screen but this doesn't work in a gem... So I had to change to a module include.
