### PR TITLE
Removed duplicate method definition

### DIFF
--- a/lib/ProMotion/screen_helpers/screen_elements.rb
+++ b/lib/ProMotion/screen_helpers/screen_elements.rb
@@ -27,17 +27,5 @@ module ProMotion
       return self.view.frame
     end
 
-    def content_height(view)
-      height = 0
-      view.subviews.each do |subview|
-        next if subview.isHidden
-        y = subview.frame.origin.y
-        h = subview.frame.size.height
-        if (y + h) > height
-          height = y + h
-        end
-      end
-      height
-    end
   end
 end


### PR DESCRIPTION
This method was already defined by `ProMotion::ViewHelpers` and is being needlessly overwritten here.
