### PR TITLE
ScreenNavigation::open_screen refactored, more tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    ProMotion (0.5.1)
+    ProMotion (0.5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    motion-stump (0.2.0)
+    motion-stump (0.2.1)
 
 PLATFORMS
   ruby

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -1,4 +1,2 @@
-class AppDelegate < ProMotion::AppDelegateParent
-  def on_load(application, launch_options)
-  end
+class AppDelegate
 end

--- a/lib/ProMotion/screen_helpers/screen_navigation.rb
+++ b/lib/ProMotion/screen_helpers/screen_navigation.rb
@@ -1,55 +1,35 @@
 module ProMotion
   module ScreenNavigation
-    # TODO: De-uglify this method.
+
     def open_screen(screen, args = {})
-      # Instantiate screen if given a class
-      screen = screen.new if screen.respond_to?(:new)
-
-      screen.parent_screen = self if screen.respond_to?("parent_screen=")
       
-      screen.title = args[:title] if args[:title] && screen.respond_to?("title=")
+      # Apply properties to instance
+      screen = setup_screen_for_open(screen, args)
+      ensure_wrapper_controller_in_place(screen, args)
 
-      screen.modal = args[:modal] if args[:modal] && screen.respond_to?("modal=")
-      
-      screen.hidesBottomBarWhenPushed = args[:hide_tab_bar] unless args[:hide_tab_bar].nil?
-
-      screen.add_nav_bar if args[:nav_bar] && screen.respond_to?(:add_nav_bar)
-
-      unless args[:close_all] || args[:modal]
-        screen.navigation_controller ||= self.navigation_controller if screen.respond_to?("navigation_controller=")
-        screen.tab_bar ||= self.tab_bar if screen.respond_to?("tab_bar=")
-      end
-
-      screen.send(:on_load) if screen.respond_to?(:on_load)
-      
-      animated = args[:animated]
-      animated ||= true
+      screen.send(:on_load) if screen.respond_to?(:on_load)      
+      animated = args[:animated] || true
 
       if args[:close_all]
-        open_root_screen(screen)
+        open_root_screen screen
+
       elsif args[:modal]
-        vc = screen
-        vc = screen.main_controller if screen.respond_to?(:main_controller)
-        self.presentModalViewController(vc, animated:animated)
+        present_modal_view_controller screen, animated
+
       elsif args[:in_tab] && self.tab_bar
-        vc = open_tab(args[:in_tab])
-        if vc
-          if vc.is_a?(UINavigationController)
-            screen.navigation_controller = vc if screen.respond_to?("navigation_controller=")
-            push_view_controller(screen, vc)
-          else
-            self.tab_bar.selectedIndex = vc.tabBarItem.tag
-          end
-        else
-          Console.log("No tab bar item '#{args[:in_tab]}'", with_color: Console::RED_COLOR)
-        end
+        present_view_controller_in_tab_bar_controller screen, args[:in_tab]
+
       elsif self.navigation_controller
         push_view_controller screen
+
       elsif screen.respond_to?(:main_controller)
         open_view_controller screen.main_controller
+
       else
         open_view_controller screen
+
       end
+
     end
     alias :open :open_screen
 
@@ -69,20 +49,15 @@ module ProMotion
       
       # Pop current view, maybe with arguments, if in navigation controller
       if self.is_modal?
-        self.parent_screen.dismissViewControllerAnimated(args[:animated], completion: lambda {
-          send_on_return(args)
-        })
-      elsif self.navigation_controller
-        if args[:to_screen] && args[:to_screen].is_a?(UIViewController)
-          self.parent_screen = args[:to_screen]
-          self.navigation_controller.popToViewController(args[:to_screen], animated: args[:animated])
-        else
-          self.navigation_controller.popViewControllerAnimated(args[:animated])
-        end
+        close_modal_screen args
 
+      elsif self.navigation_controller
+        close_nav_screen args
         send_on_return(args) # TODO: this would be better implemented in a callback or view_did_disappear.
+
       else
         Console.log("Tried to close #{self.to_s}; however, this screen isn't modal or in a nav bar.", withColor: Console::PURPLE_COLOR)
+        
       end
     end
     alias :close :close_screen
@@ -99,7 +74,7 @@ module ProMotion
     end
 
     def open_view_controller(vc)
-      UIApplication.sharedApplication.delegate.load_root_view vc
+      app_delegate.load_root_view vc
     end
 
     def push_view_controller(vc, nav_controller=nil)
@@ -107,5 +82,78 @@ module ProMotion
       nav_controller ||= self.navigation_controller
       nav_controller.pushViewController(vc, animated: true)
     end
+
+
+
+
+    protected
+
+    def setup_screen_for_open(screen, args={})
+
+      # Instantiate screen if given a class
+      screen = screen.new if screen.respond_to?(:new)
+
+      # Set parent, title & modal properties
+      screen.parent_screen = self if screen.respond_to?("parent_screen=")
+      screen.title = args[:title] if args[:title] && screen.respond_to?("title=")
+      screen.modal = args[:modal] if args[:modal] && screen.respond_to?("modal=")
+      
+      # Hide bottom bar?
+      screen.hidesBottomBarWhenPushed = args[:hide_tab_bar] == true
+
+      # Wrap in a PM::NavigationController?
+      screen.add_nav_bar if args[:nav_bar] && screen.respond_to?(:add_nav_bar)
+
+      # Return modified screen instance
+      screen
+
+    end
+
+    def ensure_wrapper_controller_in_place(screen, args={})
+      unless args[:close_all] || args[:modal]
+        screen.navigation_controller ||= self.navigation_controller if screen.respond_to?("navigation_controller=")
+        screen.tab_bar ||= self.tab_bar if screen.respond_to?("tab_bar=")
+      end
+    end
+
+    def present_modal_view_controller(screen, animated)
+      vc = screen
+      vc = screen.main_controller if screen.respond_to?(:main_controller)
+      self.presentModalViewController(vc, animated:animated)
+    end
+
+    def present_view_controller_in_tab_bar_controller(screen, tab_name)
+      vc = open_tab tab_name
+      if vc
+
+        if vc.is_a?(UINavigationController)
+          screen.navigation_controller = vc if screen.respond_to?("navigation_controller=")
+          push_view_controller(screen, vc)
+        else
+          self.tab_bar.selectedIndex = vc.tabBarItem.tag
+        end
+
+      else
+        Console.log("No tab bar item '#{tab_name}'", with_color: Console::RED_COLOR)
+      end
+    end
+
+    def close_modal_screen(args={})
+      args[:animated] ||= true
+      self.parent_screen.dismissViewControllerAnimated(args[:animated], completion: lambda {
+        send_on_return(args)
+      })
+    end
+
+    def close_nav_screen(args={})
+      args[:animated] ||= true
+      if args[:to_screen] && args[:to_screen].is_a?(UIViewController)
+        self.parent_screen = args[:to_screen]
+        self.navigation_controller.popToViewController(args[:to_screen], animated: args[:animated])
+      else
+        self.navigation_controller.popViewControllerAnimated(args[:animated])
+      end
+    end
+
   end
 end

--- a/spec/helpers/basic_screen.rb
+++ b/spec/helpers/basic_screen.rb
@@ -1,0 +1,2 @@
+class BasicScreen < ProMotion::Screen
+end

--- a/spec/helpers/home_screen.rb
+++ b/spec/helpers/home_screen.rb
@@ -7,4 +7,7 @@ class HomeScreen < ProMotion::Screen
     set_nav_bar_left_button "Cancel", action: :return_to_some_other_screen, type: UIBarButtonItemStylePlain
   end
 
+  def on_return(args={})
+  end
+
 end

--- a/spec/screen_helpers_spec.rb
+++ b/spec/screen_helpers_spec.rb
@@ -1,0 +1,189 @@
+describe "screen helpers" do
+
+  describe "screen elements" do
+
+    before do
+      @screen = HomeScreen.new
+      @screen.on_load
+      @subview = UIView.alloc.initWithFrame CGRectZero
+    end
+
+    it "should add a subview" do
+      @screen.add @subview
+      @screen.view.subviews.count.should == 1
+    end
+
+    it "should set attributes before adding a subview" do
+      @screen.add @subview, backgroundColor: UIColor.redColor
+      @screen.view.subviews.first.backgroundColor.should == UIColor.redColor
+    end
+
+    it "should let you remove a view" do
+      @screen.view.addSubview @subview
+      @screen.remove @subview
+      @screen.view.subviews.count.should == 0
+    end
+
+  end
+
+
+  describe "screen navigation" do
+
+    before do
+      @screen = HomeScreen.new nav_bar: true
+      @screen.on_load
+      @second_vc = UIViewController.alloc.initWithNibName(nil, bundle:nil)
+    end
+
+    it "#push_view_controller should use the default navigation controller if not provided" do
+      vcs = @screen.navigation_controller.viewControllers
+      @screen.push_view_controller @second_vc
+      @screen.navigation_controller.viewControllers.count.should == vcs.count + 1
+    end
+
+    it "#push_view_controller should use a provided navigation controller" do
+      second_nav_controller = UINavigationController.alloc.initWithRootViewController @screen
+      @screen.push_view_controller @second_vc, second_nav_controller
+      second_nav_controller.viewControllers.count.should == 2
+    end
+
+    it "should return the application delegate" do
+      @screen.app_delegate.should == UIApplication.sharedApplication.delegate
+    end
+
+
+
+    describe "opening a screen" do
+
+      it "should create an instance from class when opening a new screen" do
+        @screen.send(:setup_screen_for_open, BasicScreen).should.be.instance_of BasicScreen
+      end
+
+      it "should apply properties when opening a new screen" do
+        new_screen = @screen.send(:setup_screen_for_open, BasicScreen, title: 'Some Title', modal: true, hide_tab_bar: true, nav_bar: true)
+
+        new_screen.parent_screen.should == @screen
+        new_screen.title.should == 'Some Title'
+        new_screen.is_modal?.should == true
+        new_screen.hidesBottomBarWhenPushed.should == true
+        new_screen.has_nav_bar?.should == true
+      end
+
+      it "should present the #main_controller when showing a modal screen" do
+        new_screen = @screen.send(:setup_screen_for_open, BasicScreen, modal: true)
+
+        @screen.mock!('presentModalViewController:animated:') do |vc, animated|
+          vc.should == new_screen.main_controller
+          animated.should == true
+        end
+        @screen.send(:present_modal_view_controller, new_screen, true)
+      end
+
+      # TODO: Implement this test
+      it "should push screen onto nav controller stack inside a tab bar"
+
+      # TODO: Implement this test
+      it "should set the tab bar selectedIndex when opening a screen inside a tab bar"
+
+      it "should open a root screen if :close_all is provided" do
+        @screen.mock!(:open_root_screen) { |screen| screen.should.be.instance_of BasicScreen }
+        @screen.open_screen BasicScreen, close_all: true
+      end
+
+      it "should present a modal screen if :modal is provided" do
+        @screen.mock!(:present_modal_view_controller) do |screen, animated|
+          screen.should.be.instance_of BasicScreen
+          animated.should == true
+        end
+        @screen.open_screen BasicScreen, modal: true
+      end
+
+      it "should open screen in tab bar if :in_tab is provided" do
+        @screen.stub!(:tab_bar, return: true)
+        @screen.mock!(:present_view_controller_in_tab_bar_controller) do |screen, tab_name|
+          screen.should.be.instance_of BasicScreen
+          tab_name.should == 'my_tab'
+        end
+        @screen.open_screen BasicScreen, in_tab: 'my_tab'
+      end
+
+      it "should pop onto navigation controller if current screen is on nav stack already" do
+        @screen.mock!(:push_view_controller) { |vc| vc.should.be.instance_of BasicScreen }
+        @screen.open_screen BasicScreen
+      end
+
+      it "should open the main controller if no options are provided" do
+        parent_screen = HomeScreen.new
+        nav_controller = ProMotion::NavigationController.new
+        new_screen = BasicScreen.new
+        new_screen.stub! :main_controller, return: nav_controller
+
+        parent_screen.mock!(:open_view_controller) { |vc| vc.should.be == nav_controller  }
+        parent_screen.open_screen new_screen
+      end
+
+      it "should open the provided view controller if no other conditions are met" do
+        parent_screen = HomeScreen.new
+        new_screen = BasicScreen.new
+        parent_screen.mock!(:open_view_controller) { |vc| vc.should.be == new_screen }
+        parent_screen.open_screen new_screen
+      end
+
+    end
+
+
+    describe "closing a screen" do
+
+      before do
+        @second_screen = BasicScreen.new
+      end
+
+      it "should close a modal screen" do
+        parent_screen = HomeScreen.new
+        @screen.parent_screen = parent_screen
+        @screen.modal = true
+
+        @screen.mock!(:close_modal_screen) { |args| args.should.be.instance_of Hash }
+        @screen.close
+      end
+
+      it "#close_modal_screen should call #send_on_return" do
+        parent_screen = HomeScreen.new
+        @screen.parent_screen = parent_screen
+        @screen.modal = true
+
+        @screen.mock!(:send_on_return) { |args| args.should.be.instance_of Hash }
+        parent_screen.mock!('dismissViewControllerAnimated:completion:') do |animated, completion|
+          animated.should == true
+          completion.should.be.instance_of Proc
+          completion.call
+        end
+        @screen.close
+      end
+
+      it "#close should pop from the navigation controller" do
+        @screen.navigation_controller.mock!(:popViewControllerAnimated) { |animated| animated.should == true }
+        @screen.close
+      end
+
+      it "#send_on_return shouldn't pass args to parent screen if there are none" do
+        parent_screen = HomeScreen.new
+        @screen.parent_screen = parent_screen
+
+        parent_screen.mock!(:on_return) { |args| args.count.should == 0 }
+        @screen.send_on_return
+      end
+
+      it "#send_on_return should pass args to parent screen" do
+        parent_screen = HomeScreen.new
+        @screen.parent_screen = parent_screen
+
+        parent_screen.mock!(:on_return) { |args| args[:key].should == :value }
+        @screen.send_on_return key: :value
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
- Refactors the `#open_screen` method into smaller, more easier tested methods
- Adds tests for `#add` & `#remove` for views
- Adds tests for opening & closing screens
- Stubbed tests for tab bar, bit complex to test at the moment, might go with a UI acceptance test instead of unit testing, not sure.
