### PR TITLE
SplitScreen with nav_bar and tab_bar

### DIFF
--- a/lib/ProMotion/screen_helpers/screen_navigation.rb
+++ b/lib/ProMotion/screen_helpers/screen_navigation.rb
@@ -18,6 +18,26 @@ module ProMotion
 
       elsif args[:in_tab] && self.tab_bar
         present_view_controller_in_tab_bar_controller screen, args[:in_tab]
+        
+      elsif self.split_screen
+        # get the button of the old detail screen
+        nav_vc=self.split_screen.viewControllers.last
+        # screen in a navcontroller?
+        if nav_vc.is_a?(ProMotion::NavigationController)
+          nav_vc=nav_vc.childViewControllers[0]
+        end
+        button=nav_vc.navigationItem.leftBarButtonItem
+        #-set split-menu button when needed
+        if button and !screen.is_modal?
+          screen.navigationItem.leftBarButtonItem=button
+        end
+        #-set split screen for new screen
+        screen.split_screen=self.split_screen
+        self.split_screen.delegate=screen
+        s=screen
+        s=screen.main_controller if screen.respond_to?(:main_controller)
+        a=[self.split_screen.viewControllers[0], s]
+        self.split_screen.viewControllers=a
 
       elsif self.navigation_controller
         push_view_controller screen

--- a/lib/ProMotion/screen_helpers/split_screen.rb
+++ b/lib/ProMotion/screen_helpers/split_screen.rb
@@ -5,7 +5,14 @@ module ProMotion
       detail = detail.new if detail.respond_to?(:new)
       
       split = SplitViewController.alloc.init
-      split.viewControllers = [ master, detail ]
+      
+      split.viewControllers = [ master, detail ].collect { |vc|
+        if vc.navigation_controller
+          vc.navigation_controller
+        else
+          vc
+        end
+      }
       split.delegate = self
       
       [master, detail].each do |s|
@@ -24,11 +31,21 @@ module ProMotion
     
     def splitViewController(svc, willHideViewController: vc, withBarButtonItem: button, forPopoverController: pc)
       button.title = vc.title
-      svc.viewControllers.last.navigationItem.leftBarButtonItem = button;
+      nav_vc=svc.viewControllers.last
+      # screen in a navcontroller?
+      if nav_vc.is_a?(ProMotion::NavigationController)
+        nav_vc=nav_vc.childViewControllers[0]
+      end
+      nav_vc.navigationItem.leftBarButtonItem = button
     end
 
     def splitViewController(svc, willShowViewController: vc, invalidatingBarButtonItem: barButtonItem)
-      svc.viewControllers.last.navigationItem.leftBarButtonItem = nil
+      nav_vc=svc.viewControllers.last
+      # screen in a navcontroller?
+      if nav_vc.is_a?(ProMotion::NavigationController)
+        nav_vc=nav_vc.childViewControllers[0]
+      end
+      nav_vc.navigationItem.leftBarButtonItem = nil
     end
   end
 end


### PR DESCRIPTION
Here are a patch how I can use nag_bar and tab_bar with SplitScreen.
Opening new DetailScreen with a normal open.
Possibly I have overlooked this functionality in 0.6.

Example:

``` ruby
open_tab_bar(
  create_split_screen(
    ListScreen.new(nav_bar: true, title: "List"),
    DetailScreen.new(nav_bar: true, title: "Details")
   ),
  OptionsScreen.new(nav_bar: true)
)
```
