### PR TITLE
Added tests to support #74

### DIFF
--- a/spec/helpers/screen_module_view_controller.rb
+++ b/spec/helpers/screen_module_view_controller.rb
@@ -1,0 +1,4 @@
+class ScreenModuleViewController < UIViewController
+  include PM::ScreenModule
+  title 'Test Title'
+end

--- a/spec/screen_module_spec.rb
+++ b/spec/screen_module_spec.rb
@@ -1,0 +1,13 @@
+describe "PM::ScreenModule" do
+
+  before { @subject = ScreenModuleViewController.new }
+
+  it 'should have PM::ScreenModule in ancestors' do
+    @subject.class.ancestors.include?(PM::ScreenModule).should == true
+  end
+
+  it 'should have a title from class method #title' do
+    @subject.title.should == 'Test Title'
+  end
+
+end


### PR DESCRIPTION
Issue #74 mentions that the following does not work:

``` ruby
class ScreenModuleViewController < UIViewController
  include PM::ScreenModule
  title 'Test Title'
end
```

This adds to the test suite to verify that it does indeed function properly.
