### PR TITLE
Allow user to specify a UIBarButtonItem as the title for a nav bar button item.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ProMotion (0.6.0)
+    ProMotion (0.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ If you pass `:system` for the title, then you can get a system item. E.g.:
 set_nav_bar_right_button nil, action: :add_something, system_icon: UIBarButtonSystemItemAdd
 ```
 
+Additionally, if you pass an instance of a `UIBarButtonItem`, the `UIBarButton` will automatically display that particular button item.
+
+```ruby
+set_nav_bar_left_button self.editButtonItem
+```
+
 ## Opening and closing screens
 
 If the user taps something and you want to open a new screen, it's easy. Just use `open` and pass in the screen class

--- a/lib/ProMotion/screens/_screen_module.rb
+++ b/lib/ProMotion/screens/_screen_module.rb
@@ -88,6 +88,8 @@ module ProMotion
           UIBarButtonItem.alloc.initWithImage(args[:title], style: args[:style], target: args[:target], action: args[:action])
         when Symbol, NilClass
           UIBarButtonItem.alloc.initWithBarButtonSystemItem(args[:system_icon], target: args[:target], action: args[:action]) if args[:system_icon]
+        when UIBarButtonItem
+          args[:title]
         else
           PM.logger.error("Please supply a title string, a UIImage or :system.")
       end

--- a/spec/screen_helpers_spec.rb
+++ b/spec/screen_helpers_spec.rb
@@ -68,6 +68,15 @@ describe "screen helpers" do
       @screen.navigationItem.leftBarButtonItem.image.should == image
     end
 
+    it "should add a left UIBarButtonItem" do
+      @screen.set_nav_bar_left_button @screen.editButtonItem
+      @screen.navigationItem.leftBarButtonItem.class.should == UIBarButtonItem
+    end
+
+    it "should add a right UIBarButtonItem" do
+      @screen.set_nav_bar_right_button @screen.editButtonItem
+      @screen.navigationItem.rightBarButtonItem.class.should == UIBarButtonItem
+    end
   end
 
   describe "screen navigation" do


### PR DESCRIPTION
Hey!

I needed a way to pass `self.editButtonItem` into the nav bar via `set_nav_bar_left_button` and came up with the following solution:

``` ruby
set_nav_bar_left_button self.editButtonItem
# or
set_nav_bar_right_button self.editButtonItem
```

Thanks!
