### PR TITLE
NSNotificationCenter Integration :: Concept, Please Review!

### DIFF
--- a/lib/ProMotion/notification_center/notification_center_helper.rb
+++ b/lib/ProMotion/notification_center/notification_center_helper.rb
@@ -1,0 +1,49 @@
+module ProMotion
+  module NotificationCenterCallback
+    def observers
+      @observers ||= []
+    end
+
+    def observe(*args)
+      observers << args
+    end
+  end
+  module NotificationCenterHelper
+    def active_observers
+      @active_observers ||= []
+    end
+    def has_observers?
+      @active_observers.any?
+    end
+    def notification_center_setup
+      if self.class.respond_to?(:observers)
+        self.class.observers.each do |observer|
+          name = observer.shift
+          callback, object = observer.reverse
+          if callback.nil?
+            warn "[CALLBACK ERROR] A method or proc must be provided for observer #{name}"
+            next
+          end
+          callback = method(callback).to_proc unless callback.is_a? Proc
+          observer = NSNotificationCenter.defaultCenter.addObserverForName(name, object:object, queue: NSOperationQueue.mainQueue, usingBlock:callback)
+          active_observers << observer
+        end
+      end
+    end
+    def notification_center_teardown
+      active_observers.each do |observer|
+        NSNotificationCenter.defaultCenter.removeObserver(observer)
+        active_observers.delete(observer)
+      end
+    end
+    def post_notifications(notifications)
+      unless notifications.nil?
+        notifications = [notifications] unless notifications.is_a? Array
+        notifications.each do |notification|
+          notification[:object] ||= ""
+          NSNotificationCenter.defaultCenter.postNotificationName(notification[:name], object: notification[:object], userInfo: notification[:user_info])
+        end
+      end
+    end
+  end
+end

--- a/lib/ProMotion/screen_helpers/screen_navigation.rb
+++ b/lib/ProMotion/screen_helpers/screen_navigation.rb
@@ -52,6 +52,8 @@ module ProMotion
       args ||= {}
       args[:animated] ||= true
 
+      post_notifications(args[:notify])
+      notification_center_teardown if self.respond_to?(:notification_center_teardown)
       if self.is_modal?
         close_modal_screen args
 

--- a/lib/ProMotion/screens/_screen_module.rb
+++ b/lib/ProMotion/screens/_screen_module.rb
@@ -5,6 +5,7 @@ module ProMotion
     include ProMotion::SystemHelper
     include ProMotion::ScreenTabs
     include ProMotion::SplitScreen if NSBundle.mainBundle.infoDictionary["UIDeviceFamily"].include?("2")
+    include ProMotion::NotificationCenterHelper
 
     attr_accessor :parent_screen, :first_screen, :tab_bar_item, :tab_bar, :modal, :split_screen, :title
 
@@ -24,6 +25,7 @@ module ProMotion
       self.navigationController.toolbarHidden = !args[:toolbar] unless args[:toolbar].nil?
       self.on_init if self.respond_to?(:on_init)
       self.table_setup if self.respond_to?(:table_setup)
+      self.notification_center_setup if self.respond_to?(:notification_center_setup)
       self
     end
 

--- a/lib/ProMotion/screens/screen.rb
+++ b/lib/ProMotion/screens/screen.rb
@@ -3,5 +3,6 @@ module ProMotion
     # You can inherit a screen from any UIViewController if you include the ScreenModule
     # Just make sure to implement the Obj-C methods in cocoatouch/ViewController.rb.
     include ProMotion::ScreenModule
+    extend ProMotion::NotificationCenterCallback
   end
 end

--- a/lib/ProMotion/screens/table_screen.rb
+++ b/lib/ProMotion/screens/table_screen.rb
@@ -3,13 +3,16 @@ module ProMotion
   # Just make sure to implement the Obj-C methods in cocoatouch/TableViewController.rb.
   class TableScreen < TableViewController
     include ProMotion::TableScreenModule
+    extend ProMotion::NotificationCenterCallback
   end
 
   class GroupedTableScreen < TableScreen
     include ProMotion::MotionTable::GroupedTable
+    extend ProMotion::NotificationCenterCallback
   end
 
   class SectionedTableScreen < TableScreen
     include ProMotion::MotionTable::SectionedTable
+    extend ProMotion::NotificationCenterCallback
   end
 end

--- a/spec/helpers/notification_center_screen.rb
+++ b/spec/helpers/notification_center_screen.rb
@@ -1,0 +1,31 @@
+class Something
+  WORTH_WATCHING = 'NSSomethingWorthWatching'
+end
+class NotificationCenterScreen < PM::Screen
+  title "Notification Center"
+  observe Something::WORTH_WATCHING, :talk_about_it
+
+  def has_changed?
+    @changed ||= false
+  end
+
+  def talk_about_it(notification)
+    @changed = true 
+  end
+
+  def will_appear
+    set_attributes self.view, {
+      backgroundColor: UIColor.whiteColor
+    }
+    button = add UIButton.buttonWithType(UIButtonTypeRoundedRect), {}
+    button.setTitle "Open Modal", forState: UIControlStateNormal
+    button.sizeToFit
+    button.frame = [[0,0],button.frame.size]
+    button.addTarget self, action: "open_modal", forControlEvents: UIControlEventTouchUpInside
+  end
+
+  def open_modal
+    open NotificationModalScreen.new, modal: true
+  end
+
+end

--- a/spec/helpers/notification_modal_screen.rb
+++ b/spec/helpers/notification_modal_screen.rb
@@ -1,0 +1,9 @@
+class NotificationModalScreen < ProMotion::Screen
+  title 'I am modal'
+
+  def dismiss_with_notification
+    a = ''
+    close notify: { name: Something::WORTH_WATCHING, object: a }
+  end
+
+end

--- a/spec/unit/notification_center_helper_spec.rb
+++ b/spec/unit/notification_center_helper_spec.rb
@@ -1,0 +1,17 @@
+describe "PM::NotificationHelper" do
+  before do
+    @app = TestDelegate.new
+    @subject = NotificationCenterScreen.new
+ end
+
+  it 'should have active observers' do
+    @subject.active_observers.count.should == 1
+    @subject.has_changed?.should == false
+    notification_screen = NotificationModalScreen.new
+    @app.open notification_screen, modal: true
+    notification_screen.dismiss_with_notification
+    @subject.has_changed?.should == true
+  end
+
+end
+


### PR DESCRIPTION
I am using NSNotificationCenter to observe changes throughout my app and wanted a tighter integration with ProMotion screens. This is working in my app, but I have not testing it widely and I am certain there are some short comings. Please take a moment to review and provide any feedback!
### What does it do?

The `Promotion::Screen` class has been extended to allow for observers to be defined. When `on_create` is called the observers are declared. You can use NSNotificationCenter to explicitly post to an observer, but since this is tightly coupled with `close` I have added a method call to that fires off any notifications passed with `close`.
### What's it look like?

You start by adding observers to a `Screen`

```
class UserScreen < PM::Screen
  attr_accessor :user
  observe User::CHANGED, :update_biography

  def update_biography(notification)
    # .. do something, such as: ..
    self.user = notification.object
  end
end
```

Then, you tell a screen that is closing to notify an observer with that name

```
class LoginScreen < PM::Screen
  def login
    @user = User.login!
    # .. login code, and then ..
    close notify: { name: User::CHANGED, object: @user }
  end
end
```

---

I'm not convinced this is the cleanest implementation, but so far it has worked as expected in the app I've built. I'm new to both iOS development and RubyMotion, so if I'm missing the point of something or have overlooked something just let me know!
