### PR TITLE
Transparent backgroundColor of the labels

### DIFF
--- a/lib/ProMotion/screens/_tables/table_view_cell_module.rb
+++ b/lib/ProMotion/screens/_tables/table_view_cell_module.rb
@@ -59,6 +59,7 @@ module ProMotion
     def set_subtitle
       if data_cell[:subtitle] && self.detailTextLabel
         self.detailTextLabel.text = data_cell[:subtitle]
+        self.detailTextLabel.backgroundColor = UIColor.clearColor
         self.detailTextLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth
       end
       self
@@ -137,6 +138,7 @@ module ProMotion
       else
         cell_title = data_cell[:title]
         cell_title ||= ""
+        self.textLabel.backgroundColor = UIColor.clearColor
         self.textLabel.text = cell_title
       end
       


### PR DESCRIPTION
The backgroundColor of the Labels should be transparent that the UIView backgroundColor shines through everywhere.

It would be nice to know when the cell-identifier need to be changed. Every attribute change who is only executed at the creation time of the cell (like the bgColor) needs a different cell-identifier.
