### PR TITLE
Support iOS 6 force rotation.

### DIFF
--- a/lib/ProMotion/cocoatouch/NavigationController.rb
+++ b/lib/ProMotion/cocoatouch/NavigationController.rb
@@ -1,7 +1,15 @@
 module ProMotion
-  class NavigationController < UINavigationController
-    def shouldAutorotate
-      visibleViewController.shouldAutorotate
-    end
-  end
+	class NavigationController < UINavigationController
+		def shouldAutorotate
+			visibleViewController.shouldAutorotate
+		end
+
+		def supportedInterfaceOrientations
+			visibleViewController.supportedInterfaceOrientations
+		end
+
+		def preferredInterfaceOrientationForPresentation
+			visibleViewController.preferredInterfaceOrientationForPresentation
+		end
+	end
 end


### PR DESCRIPTION
So i finally figured out my problem with the portrait orientation stuff.

I've added a few methods to the `NavigationController` subclass to support auto-rotation based on supported interface orientations.

Essentially, all you have to do in your view controller now is this:

``` ruby
  def shouldAutorotate
    true
  end

  def supportedInterfaceOrientations
    UIInterfaceOrientationMaskPortrait # Or any other orientation mask
  end
```

With this patch and that code in the VC, that VC will _ALWAYS_ present in portrait mode.

**Note: this hasn't been tested for iOS 5 - my 5.1 simulator crashing on load (unrelated issue to this code)**
