### PR TITLE
Bugfix for modal transition style and presentation style

### DIFF
--- a/lib/ProMotion/screens/_screen_module.rb
+++ b/lib/ProMotion/screens/_screen_module.rb
@@ -19,7 +19,7 @@ module ProMotion
         self.send("#{k}=", v) if self.respond_to?("#{k}=")
       end
 
-      self.add_nav_bar if args[:nav_bar]
+      self.add_nav_bar(args) if args[:nav_bar]
       self.navigationController.toolbarHidden = !args[:toolbar] unless args[:toolbar].nil?
       self.on_init if self.respond_to?(:on_init)
       self.table_setup if self.respond_to?(:table_setup)


### PR DESCRIPTION
Just a minor issue:

When adding a nav bar to the screen, the method `add_nav_bar` in `ProMotion::ScreenModule` checks the `args` parameter for `:transition_style` and `:presentation_style`. Only the `add_nav_bar` method is never called with a parameter. 

I've updated the method call to include the parameter. 
