### PR TITLE
Standardize setup method.

### DIFF
--- a/lib/ProMotion/screen/map_screen_module.rb
+++ b/lib/ProMotion/screen/map_screen_module.rb
@@ -5,7 +5,7 @@ module ProMotion
 
     attr_accessor :mapview
 
-    def setup
+    def screen_setup
       check_annotation_data
       @promotion_annotation_data = []
       set_up_start_position

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -21,11 +21,11 @@ module ProMotion
       self.add_nav_bar(args) if args[:nav_bar]
       self.navigationController.toolbarHidden = !args[:toolbar] unless args[:toolbar].nil?
       self.on_init if self.respond_to?(:on_init)
-      self.setup
+      self.screen_setup
       self
     end
 
-    def setup
+    def screen_setup
     end
 
     def modal?

--- a/lib/ProMotion/screen/web_screen_module.rb
+++ b/lib/ProMotion/screen/web_screen_module.rb
@@ -5,7 +5,7 @@ module ProMotion
 
     attr_accessor :webview, :external_links
 
-    def setup
+    def screen_setup
       check_content_data
       self.external_links ||= false
     end

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -2,7 +2,7 @@ module ProMotion
   module Table
     include ProMotion::ViewHelper
 
-    def setup
+    def screen_setup
       check_table_data
       set_up_table_view
       set_up_searchable


### PR DESCRIPTION
Instead of table_setup, web_setup, map_setup, etc..., just call a standard setup method. 

The PM::Screen class shouldn't know/care about methods on its subclasses that it doesn't define itself.
