### PR TITLE
Fix for table index and search field item

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -137,6 +137,17 @@ module ProMotion
       end
     end
 
+    def tableView(tableView, sectionForSectionIndexTitle:title, atIndex:index)
+      return index unless ["{search}", UITableViewIndexSearch].include?(self.table_data_index[0])
+
+      if index == 0
+        tableView.setContentOffset(CGPointZero, animated:false)
+        NSNotFound
+      else
+        index-1
+      end
+    end
+
     def deleteRowsAtIndexPaths(indexPaths, withRowAnimation:animation)
       PM.logger.warn "ProMotion expects you to use 'delete_cell(index_paths, animation)'' instead of 'deleteRowsAtIndexPaths(indexPaths, withRowAnimation:animation)'."
       delete_cell(indexPaths, animation)


### PR DESCRIPTION
Scroll the tableview all the way to the top when there's a search field and the table index begins with `"{search}"`. Fixes #159
