### PR TITLE
PR: Added a look_up_address convenience method

### DIFF
--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -171,11 +171,11 @@ module ProMotion
         MKCoordinateRegionMake( params[:coordinate], params[:span] )
       end
     end
-    
+
     def look_up_address(args={}, &callback)
       args[:address] = args if args.is_a? String # Assume if a string is passed that they want an address
+
       geocoder = CLGeocoder.new
-      
       return geocoder.geocodeAddressDictionary(args[:address], completionHandler: callback) if args[:address].is_a?(Hash)
       return geocoder.geocodeAddressString(args[:address].to_s, completionHandler: callback) unless args[:region]
       return geocoder.geocodeAddressString(args[:address].to_s, inRegion:args[:region].to_s, completionHandler: callback) if args[:region]

--- a/spec/helpers/map_screen.rb
+++ b/spec/helpers/map_screen.rb
@@ -1,5 +1,7 @@
 class TestMapScreen < PM::MapScreen
 
+  attr_accessor :infinite_loop_points
+
   start_position latitude: 35.090648651123, longitude: -82.965972900391, radius: 4
   title "Gorges State Park, NC"
 
@@ -46,6 +48,12 @@ class TestMapScreen < PM::MapScreen
       title: "Stairway Falls",
       subtitle: "Gorges State Park",
     }]
+  end
+
+  def lookup_infinite_loop
+    look_up_address address: "1 Infinite Loop" do |points, error|
+      self.infinite_loop_points = points
+    end
   end
 
 end

--- a/spec/unit/map_spec.rb
+++ b/spec/unit/map_spec.rb
@@ -35,5 +35,15 @@ describe "map properties" do
     @map.clear_annotations
     @map.annotations.count.should == 0
   end
-  
+
+  it "should geocode an address" do
+    @map.lookup_infinite_loop
+    wait_for_change @map, 'infinite_loop_points' do
+      placemarks = @map.infinite_loop_points
+      placemarks.count.should == 1
+      placemarks.first.postalCode.should == "95014"
+      puts placemarks.first.description.include?("Cupertino").should == true
+    end
+  end
+
 end


### PR DESCRIPTION
Hard to test since you have to wait for the response, but it works in
the REPL. The API is this:

``` ruby
look_up_address address: "1 Infinite Loop" do |points, error|
  # do something with points which is an array
end
```

Suggestions welcome -- thought this might be a good abstraction to have but I'm not stuck on it.

cc @markrickert 
