### PR TITLE
Fixing Teacup integration with PM::TableScreen

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -25,25 +25,28 @@ module ProMotion
 
     def set_cell_attributes
       data_cell_attributes = data_cell.dup
-      [:image, :accessory_action].each { |k| data_cell_attributes.delete(k) }
+      [:image, :accessory_action, :editing_style].each { |k| data_cell_attributes.delete(k) }
       set_attributes self, data_cell_attributes
       self
     end
 
     def set_background_color
-      self.backgroundView = UIView.new.tap{|v| v.backgroundColor = data_cell[:background_color]} if data_cell[:background_color]
+      self.backgroundView ||= UIView.new
+      self.backgroundView.backgroundColor = data_cell[:background_color] if data_cell[:background_color]
     end
 
     def set_accessory_view
-      if data_cell[:accessory][:view] == :switch
-        switch_view = UISwitch.alloc.initWithFrame(CGRectZero)
-        switch_view.setAccessibilityLabel(data_cell[:accessory][:accessibility_label] || data_cell[:title])
-        switch_view.addTarget(self.table_screen, action: "accessory_toggled_switch:", forControlEvents:UIControlEventValueChanged)
-        switch_view.on = !!data_cell[:accessory][:value]
-        self.accessoryView = switch_view
-      elsif data_cell[:accessory][:view]
-        self.accessoryView = data_cell[:accessory][:view]
-        self.accessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth
+      if data_cell[:accessory]
+        if data_cell[:accessory][:view] == :switch
+          switch_view = UISwitch.alloc.initWithFrame(CGRectZero)
+          switch_view.setAccessibilityLabel(data_cell[:accessory][:accessibility_label] || data_cell[:title])
+          switch_view.addTarget(self.table_screen, action: "accessory_toggled_switch:", forControlEvents:UIControlEventValueChanged)
+          switch_view.on = !!data_cell[:accessory][:value]
+          self.accessoryView = switch_view
+        elsif data_cell[:accessory][:view]
+          self.accessoryView = data_cell[:accessory][:view]
+          self.accessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth
+        end
       else
         self.accessoryView = nil
       end

--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -79,20 +79,15 @@ module ProMotion
         value: data_cell[:accessory_value],
         action: data_cell[:accessory_action],
         arguments: data_cell[:accessory_arguments]
-      } unless data_cell[:accessory].is_a? Hash
+      } unless data_cell[:accessory].nil? || data_cell[:accessory].is_a?(Hash)
 
       data_cell
     end
 
     def build_cell_identifier(data_cell)
-      ident = "Cell"
-      unless data_cell[:accessory].nil?
-        if data_cell[:accessory][:view] == :switch
-          ident << "-switch"
-        elsif !data_cell[:accessory][:view].nil?
-          ident << "-accessory"
-        end
-      end
+      ident = "#{data_cell[:cell_class]}"
+      ident << "-#{data_cell[:stylename].to_s}" if data_cell[:stylename] # For Teacup
+      ident << "-#{data_cell[:accessory][:view].to_s}" if data_cell[:accessory]
       ident << "-subtitle" if data_cell[:subtitle]
       ident << "-remoteimage" if data_cell[:remote_image]
       ident << "-image" if data_cell[:image]


### PR DESCRIPTION
- Fixes issue #172
- Also adds `editing_style:` attribute (can be :delete, :insert, or :none) to table cells.
- Avoids re-initializing the background UIView every time
- Better cell identifiers that uses the cell class name
- No more overwriting of `cell_style:`
- Cleaner/faster accessory initialization (avoids unnecessarily creating an accessory hash when not given)
- Minor code format fixes
