### PR TITLE
Use KVO for WebScreen tests instead of arbitrary timeouts.

### DIFF
--- a/spec/functional/func_web_screen_spec.rb
+++ b/spec/functional/func_web_screen_spec.rb
@@ -18,14 +18,14 @@ describe "ProMotion::TestWebScreen functionality" do
     @webscreen.set_content(file_name)
 
     @loaded_file = File.read(File.join(NSBundle.mainBundle.resourcePath, file_name))
-    wait 1.0 do
+    wait_for_change @webscreen, 'load_finished' do
       @webscreen.html.should == @loaded_file
     end
   end
 
   it "should allow you to navigate to a website" do
     @webscreen.set_content(NSURL.URLWithString("http://www.google.com"))
-    wait 1.0 do
+    wait_for_change @webscreen, 'load_finished' do
       @webscreen.html.include?('<form action="/search"').should == true
     end
   end
@@ -33,7 +33,7 @@ describe "ProMotion::TestWebScreen functionality" do
   it "should manipulate the webscreen contents with javascript" do
     @webscreen.set_content('<h1 id="cool">Something Cool</h1>')
 
-    wait 0.5 do
+    wait_for_change @webscreen, 'load_finished' do
       @webscreen.evaluate('document.getElementById("cool").innerHTML = "Changed"')
       @webscreen.html.should == '<h1 id="cool">Changed</h1>'
     end

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -11,7 +11,7 @@ describe "web screen properties" do
   end
 
   it "should load the about html page" do
-    wait 0.5 do
+    wait_for_change @webscreen, 'load_finished' do
       @webscreen.load_finished.should == true
     end
   end


### PR DESCRIPTION
191 specifications (294 requirements), 0 failures, 0 errors
