### PR TITLE
PR: change open_screen return a screen

### DIFF
--- a/lib/ProMotion/delegate/delegate_helper.rb
+++ b/lib/ProMotion/delegate/delegate_helper.rb
@@ -48,6 +48,7 @@ module ProMotion
       self.window.rootViewController = screen.pm_main_controller
       self.window.makeKeyAndVisible
 
+      screen
     end
     alias :open :open_screen
     alias :open_root_screen :open_screen

--- a/lib/ProMotion/screen_helpers/screen_navigation.rb
+++ b/lib/ProMotion/screen_helpers/screen_navigation.rb
@@ -33,6 +33,7 @@ module ProMotion
 
       end
 
+      screen
     end
     alias :open :open_screen
 

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -29,9 +29,10 @@ describe "PM::Delegate" do
   it "should set home_screen when opening a new screen" do
 
     @subject.application(UIApplication.sharedApplication, didFinishLaunchingWithOptions: nil)
-    @subject.open BasicScreen.new(nav_bar: true)
+    screen = @subject.open BasicScreen.new(nav_bar: true)
     @subject.home_screen.should.be.kind_of BasicScreen
     @subject.window.rootViewController.should.be.kind_of UINavigationController
+    screen.should.be.kind_of BasicScreen
 
   end
 

--- a/spec/unit/screen_helpers_spec.rb
+++ b/spec/unit/screen_helpers_spec.rb
@@ -141,7 +141,8 @@ describe "screen helpers" do
 
       it "should open a root screen if :close_all is provided" do
         @screen.mock!(:open_root_screen) { |screen| screen.should.be.instance_of BasicScreen }
-        @screen.open BasicScreen, close_all: true
+        screen = @screen.open BasicScreen, close_all: true
+        screen.should.be.kind_of BasicScreen
       end
 
       it "should present a modal screen if :modal is provided" do
@@ -149,7 +150,8 @@ describe "screen helpers" do
           screen.should.be.instance_of BasicScreen
           animated.should == true
         end
-        @screen.open BasicScreen, modal: true
+        screen = @screen.open BasicScreen, modal: true
+        screen.should.be.kind_of BasicScreen
       end
       
       it "should present a modal screen if open_modal is used" do
@@ -157,7 +159,8 @@ describe "screen helpers" do
           screen.should.be.instance_of BasicScreen
           animated.should == true
         end
-        @screen.open_modal BasicScreen
+        screen = @screen.open_modal BasicScreen
+        screen.should.be.kind_of BasicScreen
       end
 
       it "should respect animated property of opening modal screens" do
@@ -167,7 +170,8 @@ describe "screen helpers" do
           animated.should == false
         end
 
-        @screen.send(:open, new_screen, animated: false, modal: true)
+        screen = @screen.send(:open, new_screen, animated: false, modal: true)
+        screen.should.be.kind_of BasicScreen
       end
 
       it "should open screen in tab bar if :in_tab is provided" do
@@ -176,17 +180,20 @@ describe "screen helpers" do
           screen.should.be.instance_of BasicScreen
           tab_name.should == 'my_tab'
         end
-        @screen.open BasicScreen, in_tab: 'my_tab'
+        screen = @screen.open BasicScreen, in_tab: 'my_tab'
+        screen.should.be.kind_of BasicScreen
       end
 
       it "should pop onto navigation controller if current screen is on nav stack already" do
         @screen.mock!(:push_view_controller) { |vc| vc.should.be.instance_of BasicScreen }
-        @screen.open BasicScreen
+        screen = @screen.open BasicScreen
+        screen.should.be.kind_of BasicScreen
       end
       
       it "should ignore its own navigation controller if current screen has a navigation controller" do
         basic = BasicScreen.new(nav_bar: true) # creates a dangling nav_bar that will be discarded.
-        @screen.open basic
+        screen = @screen.open basic
+        screen.should.be.kind_of BasicScreen
         basic.navigationController.should == @screen.navigationController
         basic.navigation_controller.should == @screen.navigationController
         @screen.navigation_controller.should == @screen.navigationController
@@ -196,7 +203,8 @@ describe "screen helpers" do
         parent_screen = HomeScreen.new
         new_screen = BasicScreen.new
         parent_screen.mock!(:open_root_screen) { |vc| vc.should.be == new_screen }
-        parent_screen.open_screen new_screen
+        screen = parent_screen.open_screen new_screen
+        screen.should == new_screen
       end
 
     end

--- a/spec/unit/split_screen_open_screen_spec.rb
+++ b/spec/unit/split_screen_open_screen_spec.rb
@@ -15,36 +15,41 @@ describe "split screen `open` functionality" do
   end
 
   it "should open a new screen in the detail view" do
-    @master_screen.open @detail_screen_2, in_detail: true
+    screen = @master_screen.open @detail_screen_2, in_detail: true
     @split_screen.detail_screen.should == @detail_screen_2
     @split_screen.viewControllers.first.should == @master_screen.pm_main_controller
     @split_screen.viewControllers.last.should == @detail_screen_2.pm_main_controller
+    screen.should == @detail_screen_2
   end
 
   it "should open a new screen in the master view" do
-    @detail_screen_1.open @detail_screen_2, in_master: true
+    screen = @detail_screen_1.open @detail_screen_2, in_master: true
     @split_screen.master_screen.should == @detail_screen_2
     @split_screen.viewControllers.first.should == @detail_screen_2.pm_main_controller
     @split_screen.viewControllers.last.should == @detail_screen_1.pm_main_controller
+    screen.should == @detail_screen_2
   end
 
   it "should open a new screen in the master view's navigation controller" do
-    @master_screen.open @detail_screen_2
+    screen = @master_screen.open @detail_screen_2
     @split_screen.detail_screen.should == @detail_screen_1 # no change
     @master_screen.navigationController.topViewController.should == @detail_screen_2
+    screen.should == @detail_screen_2
   end
 
   it "should open a new modal screen in the detail view" do
-    @detail_screen_1.open @detail_screen_2, modal: true
+    screen = @detail_screen_1.open @detail_screen_2, modal: true
     @split_screen.detail_screen.should == @detail_screen_1
     @detail_screen_1.presentedViewController.should == @detail_screen_2.pm_main_controller
+    screen.should == @detail_screen_2
   end
 
   it "should not interfere with normal non-split screen navigation" do
     home = HomeScreen.new(nav_bar: true)
     child = BasicScreen.new
-    home.open child, in_detail: true, in_master: true
+    screen = home.open child, in_detail: true, in_master: true
     home.navigation_controller.topViewController.should == child
+    screen.should == child
   end
 
 end


### PR DESCRIPTION
I came up with this idea when I was using modal view.

before:

``` ruby
def action_open_modal
  @modal_screen = ModalScreen.new
  open @modal_screen, moda: true
end
```

after:

``` ruby
def action_open_modal
  @modal_screen = open ModalScreen, moda: true
end
```
