### PR TITLE
Remove nil entries from the self.table_data var before processing while searching

### DIFF
--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -47,7 +47,7 @@ module ProMotion
 
       search_string = search_string.downcase.strip
 
-      self.data.each do |section|
+      self.data.compact.each do |section|
         new_section = {}
         new_section[:cells] = []
 


### PR DESCRIPTION
I ran into an issue with an app where when initiating a search the `table_data`'s `self.data` variable contained:

``` ruby
[
  nil,
  [ACTUAL DATA HERE]
]
```

This pull request simply runs `compact` on the array before looping over it to remove all the nil values form the array. It shouldn't impact any other functionality.

``` bash
196 specifications (331 requirements), 0 failures, 0 errors
```
