### PR TITLE
Allow the parent VC to tell if the current data is being filtered or not.

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -38,9 +38,8 @@ module ProMotion
       table_view
     end
 
-    def is_searching?
-      return true if self.class.respond_to?(:get_searchable) && @promotion_table_data.filtered == true
-      false
+    def searching?
+      @promotion_table_data.filtered
     end
 
     def update_table_view_data(data)


### PR DESCRIPTION
`is_searching?` returns true if the tablescreen is searchable and if the data is currently being filtered.

No new tests.

``` bash
196 specifications (331 requirements), 0 failures, 0 errors
```
