### PR TITLE
Changed cell_deleted to on_cell_deleted, allowed returning false to...

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -104,12 +104,17 @@ module ProMotion
     def delete_row(index_paths, animation = nil)
       animation ||= UITableViewRowAnimationAutomatic
       index_paths = Array(index_paths)
+      deletable_index_paths = []
 
       index_paths.each do |index_path|
-        cell_deleted(@promotion_table_data.cell(index_path: index_path)) if self.respond_to?("cell_deleted:")
-        @promotion_table_data.delete_cell(index_path: index_path)
+        delete_cell = false
+        delete_cell = send(:on_cell_deleted, @promotion_table_data.cell(index_path: index_path)) if self.respond_to?("on_cell_deleted:")
+        unless delete_cell == false
+          @promotion_table_data.delete_cell(index_path: index_path)
+          deletable_index_paths << index_path
+        end
       end
-      table_view.deleteRowsAtIndexPaths(index_paths, withRowAnimation:animation)
+      table_view.deleteRowsAtIndexPaths(deletable_index_paths, withRowAnimation:animation) if deletable_index_paths.length > 0
     end
 
     def table_view_cell(params={})

--- a/spec/functional/func_table_screen_spec.rb
+++ b/spec/functional/func_table_screen_spec.rb
@@ -34,24 +34,24 @@ describe "ProMotion::TestTableScreen functionality" do
   end
 
   it "should delete the specified row from the table view on tap" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
+    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
     tap("Delete the row below")
     wait 0.3 do
-      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 5
+      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
     end
   end
 
   it "should delete the specified row from the table view on tap with an animation" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
+    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
     tap("Delete the row below with an animation")
     wait 0.3 do
-      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 5
+      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
     end
   end
 
   # TODO: Why is it so complicated to find the delete button??
   it "should use editing_style to delete the table row" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
+    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
     @controller.cell_was_deleted.should != true
     flick("Just another deletable blank row", :to => :left)
 
@@ -61,8 +61,27 @@ describe "ProMotion::TestTableScreen functionality" do
         if subview.class == UITableViewCellDeleteConfirmationControl
           tap subview
           wait 0.25 do
-            @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 5
+            @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
             @controller.cell_was_deleted.should == true
+          end
+        end
+      end
+    end
+  end
+
+  it "should not allow deleting if on_cell_delete returns `false`" do
+    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
+    @controller.cell_was_deleted.should != true
+    flick("A non-deletable blank row", :to => :left)
+
+    wait 0.25 do
+      # Tap the delete button
+      view('A non-deletable blank row').superview.superview.subviews.each do |subview|
+        if subview.class == UITableViewCellDeleteConfirmationControl
+          tap subview
+          wait 0.25 do
+            @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
+            @controller.cell_was_deleted.should != false
           end
         end
       end

--- a/spec/helpers/table_screen.rb
+++ b/spec/helpers/table_screen.rb
@@ -18,6 +18,7 @@ class TestTableScreen < ProMotion::TableScreen
         { title: "Add New Row", action: :add_tableview_row },
         { title: "Delete the row below", action: :delete_cell, arguments: {section: 0, row:3} },
         { title: "Just another deletable blank row", editing_style: :delete },
+        { title: "A non-deletable blank row", editing_style: :delete },
         { title: "Delete the row below with an animation", action: :delete_cell, arguments: {animated: true, section: 0, row:5 } },
         { title: "Just another blank row" }
       ]
@@ -86,8 +87,12 @@ class TestTableScreen < ProMotion::TableScreen
     end
   end
 
-  def cell_deleted(cell)
-    self.cell_was_deleted = true
+  def on_cell_deleted(cell)
+    if cell[:title] == "A non-deletable blank row"
+      false 
+    else
+      self.cell_was_deleted = true
+    end
   end
 
   def increment_counter

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -12,7 +12,7 @@ describe "table screens" do
     end
 
     it "should have proper cell numbers" do
-      @screen.tableView(@screen.tableView, numberOfRowsInSection:0).should == 6
+      @screen.tableView(@screen.tableView, numberOfRowsInSection:0).should == 7
       @screen.tableView(@screen.tableView, numberOfRowsInSection:1).should == 2
       @screen.tableView(@screen.tableView, numberOfRowsInSection:2).should == 4
       @screen.tableView(@screen.tableView, numberOfRowsInSection:3).should == 3


### PR DESCRIPTION
...prevent deletion.

``` ruby
def on_cell_deleted(cell)
  if cell[:arguments][:some_value] == "something"
    App.alert "Sorry, can't delete that row."
    false
  else
    RemoteObject.delete_remotely
    # return anything *but* false to allow deletion
  end
end
```
