### PR TITLE
MapScreen: check for annotation specificities

### DIFF
--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -91,17 +91,22 @@ module ProMotion
     end
 
     def mapView(mapView, viewForAnnotation:annotation)
-      identifier = annotation.annotation_params[:identifier]
-      if view = mapView.dequeueReusableAnnotationViewWithIdentifier(identifier)
-        view.annotation = annotation
-      else
-        #Set the pin properties
-        view = MKPinAnnotationView.alloc.initWithAnnotation(annotation, reuseIdentifier:identifier)
-        view.canShowCallout = annotation.annotation_params[:show_callout]
-        view.animatesDrop = annotation.annotation_params[:animates_drop]
-        view.pinColor = annotation.annotation_params[:pin_color]
+      # Only ProMotion annotations respond to 'annotation_params'
+      if annotation.respond_to?(:annotation_params)
+        identifier = annotation.annotation_params[:identifier]
+      
+        if view = mapView.dequeueReusableAnnotationViewWithIdentifier(identifier)
+          view.annotation = annotation
+        else
+          # Set the pin properties
+          view = MKPinAnnotationView.alloc.initWithAnnotation(annotation, reuseIdentifier:identifier)
+          view.canShowCallout = annotation.annotation_params[:show_callout]
+          view.animatesDrop = annotation.annotation_params[:animates_drop]
+          view.pinColor = annotation.annotation_params[:pin_color]
+        end
+      
+        view
       end
-      view
     end
 
     def set_start_position(params={})


### PR DESCRIPTION
Hello,

I was using `MapScreen` without too much issues, but when I tried to show my user's location (using `mapview.showsUserLocation = true`), I got errors of the kind:

```
Terminating app due to uncaught exception 'NoMethodError', reason: 'map_screen_module.rb:94:in `mapView:viewForAnnotation:': undefined method `annotation_params' for #<MKUserLocation:0xa44eea0 (NoMethodError)
```

What I think happens is that iOS uses a custom annotation class, and the current code takes for granted that `annotation` responds to `annotation_params`, which is not the case in that situation.
