### PR TITLE
Use WebStub to test WebScreen

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     motion-redgreen (0.1.0)
     motion-stump (0.2.1)
     rake (10.0.4)
+    webstub (0.6.0)
 
 PLATFORMS
   ruby
@@ -18,3 +19,4 @@ DEPENDENCIES
   motion-redgreen
   motion-stump
   rake
+  webstub

--- a/ProMotion.gemspec
+++ b/ProMotion.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ProMotion::VERSION
 
+  gem.add_development_dependency("webstub")
   gem.add_development_dependency("motion-stump")
   gem.add_development_dependency("motion-redgreen")
   gem.add_development_dependency("rake")

--- a/spec/functional/func_web_screen_spec.rb
+++ b/spec/functional/func_web_screen_spec.rb
@@ -1,4 +1,9 @@
 describe "ProMotion::TestWebScreen functionality" do
+  extend WebStub::SpecHelpers
+
+  before  { disable_network_access! }
+  after   { enable_network_access! }
+
   tests PM::TestWebScreen
 
   # Override controller to properly instantiate
@@ -24,7 +29,10 @@ describe "ProMotion::TestWebScreen functionality" do
   end
 
   it "should allow you to navigate to a website" do
-    @webscreen.set_content(NSURL.URLWithString("https://www.google.com"))
+    stub_request(:get, "https://www.google.com/").
+      to_return(body: %q{Google! <form action="/search">%}, content_type: "text/html")
+
+    @webscreen.set_content(NSURL.URLWithString("https://www.google.com/"))
     wait_for_change @webscreen, 'load_finished' do
       @webscreen.html.include?('<form action="/search"').should == true
     end


### PR DESCRIPTION
WebScreen tests that hit the network should be deterministic now, as the app is cut off from the network for the duration of those specs.
