### PR TITLE
Add `indexable` & `PM::Table::Indexable`

### DIFF
--- a/lib/ProMotion/table/extensions/indexable.rb
+++ b/lib/ProMotion/table/extensions/indexable.rb
@@ -1,0 +1,13 @@
+module ProMotion
+  module Table
+    module Indexable
+      def make_indexable(params={})
+        @pm_indexable = true
+      end
+
+      def index_from_section_titles
+        @promotion_table_data.filtered ? nil : @promotion_table_data.sections.collect{ |section| section[:title][0] }
+      end
+    end
+  end
+end

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -4,6 +4,7 @@ module ProMotion
     include ProMotion::ViewHelper
     include ProMotion::Table::Searchable
     include ProMotion::Table::Refreshable
+    include ProMotion::Table::Indexable
 
     def table_view
       @table_view ||= begin
@@ -170,7 +171,13 @@ module ProMotion
       if @promotion_table_data.filtered
         nil
       else
-        self.table_data_index if self.respond_to?(:table_data_index)
+        if self.respond_to?(:table_data_index)
+          self.table_data_index
+        elsif self.class.get_indexable
+          self.index_from_section_titles
+        else
+          nil
+        end
       end
     end
 
@@ -262,6 +269,20 @@ module ProMotion
 
       def get_refreshable_params
         @refreshable_params ||= nil
+      end
+      
+      # Indexable
+      def indexable(params = {})
+        @indexable_params = params
+        @indexable = true
+      end
+
+      def get_indexable
+        @indexable ||= false
+      end
+
+      def get_indexable_params
+        @indexable_params ||= nil
       end
 
     end

--- a/spec/helpers/table_screen_indexable.rb
+++ b/spec/helpers/table_screen_indexable.rb
@@ -1,0 +1,13 @@
+class TableScreenIndexable < PM::TableScreen
+  indexable
+
+  def table_data
+    %w{ Apple Google Microsoft Oracle Sun UNIX }.map do |group_name|
+      {
+        title: "#{group_name} Group",
+        cells: [{ title: "Single cell for group #{group_name}" }]
+      }
+    end
+  end
+
+end

--- a/spec/unit/tables/table_indexable_spec.rb
+++ b/spec/unit/tables/table_indexable_spec.rb
@@ -1,0 +1,12 @@
+describe "PM::Table module" do
+  
+  before do
+    @screen = TableScreenIndexable.new
+  end
+  
+  it "should automatically return the first letter of each section" do
+    result = %w{ A G M O S U }
+    @screen.sectionIndexTitlesForTableView(@screen.table_view).should == result
+  end
+
+end


### PR DESCRIPTION
- Instead of having to implement `table_data_index`, this will get the
  first letter from each group automatically.
- Backwards compatible -- will defer to `table_data_index` if you have implemented that.

207 specifications (358 requirements), 0 failures, 0 errors

``` ruby
class MyTable < PM::TableScreen
  indexable

  def table_data
    [{
      title: "Apple",
      cells: []
    }, {
      title: "Google",
      cells: [],
    }, {
      title: "Microsoft",
      cells: []
    }]
  end
end
```
