### PR TITLE
Adding open_modal alias to delegate_helper so it can be used in app_delegate

### DIFF
--- a/lib/ProMotion/delegate/delegate_helper.rb
+++ b/lib/ProMotion/delegate/delegate_helper.rb
@@ -53,6 +53,10 @@ module ProMotion
     alias :open_root_screen :open_screen
     alias :home :open_screen
 
+    def open_modal(screen, args={})
+      open screen, args.merge({ modal: true })
+    end
+
     def apply_status_bar
       self.class.send(:apply_status_bar)
     end


### PR DESCRIPTION
The open_modal alias is missing from the delegate helper.
