### PR TITLE
Styling section views in PM::TableScreen

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -241,9 +241,33 @@ module ProMotion
       PM.logger.warn "ProMotion expects you to use 'delete_cell(index_paths, animation)'' instead of 'deleteRowsAtIndexPaths(index_paths, withRowAnimation:animation)'."
       delete_row(index_paths, animation)
     end
-    
+
+    # Section view methods
+    def tableView(table_view, viewForHeaderInSection: index)
+      section = section_at_index(index)
+
+      if section[:title_view]
+        klass      = section[:title_view]
+        view       = klass.new if klass.respond_to?(:new)
+        view.title = section[:title] if view.respond_to?(:title=)
+        view
+      else
+        nil
+      end
+    end
+
+    def tableView(table_view, heightForHeaderInSection: index)
+      section = section_at_index(index)
+
+      if section[:title_view] || (section[:title] && !section[:title].empty?)
+        section[:title_view_height] || tableView.sectionHeaderHeight
+      else
+        0.0
+      end
+    end
+
     protected
-    
+
     def map_row_animation_symbol(symbol)
       symbol ||= UITableViewRowAnimationAutomatic
       {
@@ -287,7 +311,7 @@ module ProMotion
       def get_refreshable_params
         @refreshable_params ||= nil
       end
-      
+
       # Indexable
       def indexable(params = {})
         @indexable_params = params

--- a/spec/helpers/custom_title_view.rb
+++ b/spec/helpers/custom_title_view.rb
@@ -1,0 +1,4 @@
+class CustomTitleView < UITableViewCell
+  attr_accessor :title
+end
+

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -43,6 +43,10 @@ describe "PM::Table module" do
         title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory(title: "3-2", background_color: UIColor.blueColor) ]
       },{
         title: "Table cell group 4", cells: [ custom_cell, cell_factory(title: "4-2"), cell_factory(title: "4-3"), cell_factory(title: "4-4") ]
+      },{
+        title: "Custom section title 1", title_view: CustomTitleView, cells: [ ]
+      },{
+        title: "Custom section title 2", title_view: CustomTitleView.new, title_view_height: 50, cells: [ ]
       }]
     end
 
@@ -55,7 +59,7 @@ describe "PM::Table module" do
   end
 
   it "should have the right number of sections" do
-    @subject.numberOfSectionsInTableView(@subject.table_view).should == 4
+    @subject.numberOfSectionsInTableView(@subject.table_view).should == 6
   end
 
   it "should set the section titles" do
@@ -63,6 +67,8 @@ describe "PM::Table module" do
     @subject.tableView(@subject.table_view, titleForHeaderInSection:1).should == "Table cell group 2"
     @subject.tableView(@subject.table_view, titleForHeaderInSection:2).should == "Table cell group 3"
     @subject.tableView(@subject.table_view, titleForHeaderInSection:3).should == "Table cell group 4"
+    @subject.tableView(@subject.table_view, titleForHeaderInSection:4).should == "Custom section title 1"
+    @subject.tableView(@subject.table_view, titleForHeaderInSection:5).should == "Custom section title 2"
   end
 
   it "should create the right number of cells" do
@@ -70,6 +76,8 @@ describe "PM::Table module" do
     @subject.tableView(@subject.table_view, numberOfRowsInSection:1).should == 1
     @subject.tableView(@subject.table_view, numberOfRowsInSection:2).should == 2
     @subject.tableView(@subject.table_view, numberOfRowsInSection:3).should == 4
+    @subject.tableView(@subject.table_view, numberOfRowsInSection:4).should == 0
+    @subject.tableView(@subject.table_view, numberOfRowsInSection:5).should == 0
   end
 
   it "should create the jumplist" do
@@ -102,7 +110,7 @@ describe "PM::Table module" do
 
     @subject.tableView(@subject.table_view, didSelectRowAtIndexPath:@custom_ip)
   end
-  
+
   it "should set a custom cell background image" do
     @image.should.not.be.nil
     ip = NSIndexPath.indexPathForRow(0, inSection: 3) # Cell 2-1
@@ -117,6 +125,23 @@ describe "PM::Table module" do
     cell.should.be.kind_of(UITableViewCell)
     cell.backgroundColor.should.be.kind_of(UIColor)
     cell.backgroundColor.should == UIColor.blueColor
+  end
+
+  describe("section with custom title_view") do
+
+    it "should use the correct class for section view" do
+      cell = @subject.tableView(@subject.table_view, viewForHeaderInSection: 4)
+      cell.should.be.kind_of(CustomTitleView)
+    end
+
+    it "should use the default section height if none is specified" do
+      @subject.tableView(@subject.table_view, heightForHeaderInSection:4).should == 22.0 # Built-in default
+    end
+
+    it "should use the set title_view_height if one is specified" do
+      @subject.tableView(@subject.table_view, heightForHeaderInSection:5).should == 50.0
+    end
+
   end
 
 end


### PR DESCRIPTION
Implementing issue #211

``` ruby
def table_data
  [
    title: "My section title",
    title_view: MyCustomSection,
    title_height: 50,
    cells: []
  ]
end
```

You'll have to set a title accessor on your custom title view class, as the
title you specified in table_data will be set on that attribute.

``` ruby
class MyCustomSection < UITableViewCell
  attr_accessor :title
end
```

cc: @jamonholmgren 
