### PR TITLE
tab_bar_item class method

### DIFF
--- a/lib/ProMotion/containers/tabs.rb
+++ b/lib/ProMotion/containers/tabs.rb
@@ -60,8 +60,6 @@ module ProMotion
       tab_bar_controller.viewControllers = controllers
     end
     
-    protected
-    
     def map_tab_symbol(symbol)
       @_tab_symbols ||= {
         more:         UITabBarSystemItemMore,
@@ -79,5 +77,19 @@ module ProMotion
       }
       @_tab_symbols[symbol] || symbol
     end
+    
+    module TabClassMethods
+      def tab_bar_item(args={})
+        @tab_bar_item = args
+      end
+      def get_tab_bar_item
+        @tab_bar_item
+      end
+    end
+    
+    def self.included(base)
+      base.extend(TabClassMethods)
+    end
+    
   end
 end

--- a/lib/ProMotion/map/map_screen.rb
+++ b/lib/ProMotion/map/map_screen.rb
@@ -1,5 +1,6 @@
 module ProMotion
   class MapScreen < ViewController
+    include ProMotion::ScreenModule
     include ProMotion::MapScreenModule
   end
 end

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -1,23 +1,18 @@
 module ProMotion
   module MapScreenModule
-    include ProMotion::Styling
-    include ScreenModule
-
     attr_accessor :mapview
 
     def screen_setup
-      check_annotation_data
-      @promotion_annotation_data = []
-      set_up_start_position
-    end
-
-    def on_init
       check_mapkit_included
       self.mapview ||= add MKMapView.new, {
         frame: CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height),
         resize: [ :width, :height ],
         delegate: self
       }
+      
+      check_annotation_data
+      @promotion_annotation_data = []
+      set_up_start_position
     end
 
     def view_will_appear(animated)
@@ -205,7 +200,6 @@ module ProMotion
       end
     end
     def self.included(base)
-      base.extend(ClassMethods)
       base.extend(MapClassMethods)
     end
 

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -13,13 +13,15 @@ module ProMotion
       end
 
       self.title = self.class.send(:get_title)
+      self.tab_bar_item = self.class.send(:get_tab_bar_item)
+      self.refresh_tab_bar_item if self.tab_bar_item
 
       args.each { |k, v| self.send("#{k}=", v) if self.respond_to?("#{k}=") }
 
       self.add_nav_bar(args) if args[:nav_bar]
       self.navigationController.toolbarHidden = !args[:toolbar] unless args[:toolbar].nil?
-      self.on_init if self.respond_to?(:on_init)
       self.screen_setup
+      self.on_init if self.respond_to?(:on_init)
       self
     end
 
@@ -268,6 +270,7 @@ module ProMotion
 
     def self.included(base)
       base.extend(ClassMethods)
+      base.extend(TabClassMethods) # TODO: Is there a better way?
     end
   end
 end

--- a/lib/ProMotion/web/web_screen.rb
+++ b/lib/ProMotion/web/web_screen.rb
@@ -1,5 +1,6 @@
 module ProMotion
   class WebScreen < ViewController
+    include ProMotion::ScreenModule
     include ProMotion::WebScreenModule
   end
 end

--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -1,8 +1,5 @@
 module ProMotion
   module WebScreenModule
-    include ProMotion::Styling
-    include ScreenModule
-
     attr_accessor :webview, :external_links, :detector_types
 
     def screen_setup
@@ -111,10 +108,6 @@ module ProMotion
     def open_in_safari(inRequest)
       #Open UIWebView delegate links in Safari.
       UIApplication.sharedApplication.openURL(inRequest.URL)
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
     end
 
     #UIWebViewDelegate Methods - Camelcase

--- a/spec/helpers/tab_screen.rb
+++ b/spec/helpers/tab_screen.rb
@@ -1,0 +1,4 @@
+class TabScreen < PM::Screen
+  title "Tab"
+  tab_bar_item title: "Tab Item", icon: "list"
+end

--- a/spec/unit/tab_spec.rb
+++ b/spec/unit/tab_spec.rb
@@ -1,0 +1,41 @@
+describe "tab bar functionality" do
+
+  before do
+    @app = TestDelegate.new
+
+    @tab_1 = TabScreen.new
+    @tab_2 = BasicScreen.new
+    @tab_3 = HomeScreen.new
+    @tab_4 = TestTableScreen.new
+
+    @tab_bar = @app.open_tab_bar @tab_1, @tab_2, @tab_3, @tab_4
+  end
+
+  after do
+    
+  end
+
+  it "should have created a tab bar with four items" do
+    @tab_bar.should != nil
+    @tab_bar.should.be.kind_of(UITabBarController)
+    @tab_bar.viewControllers.length.should == 4
+  end
+  
+  it "should have set a custom tab bar item" do
+    @tab_bar.tabBar.items.first.title.should == "Tab Item"
+  end
+  
+  it "should have set the others to their respective titles" do
+    @tab_bar.tabBar.items[1].title.should == "Basic"
+    @tab_bar.tabBar.items[2].title.should == "Home"
+    @tab_bar.tabBar.items[3].title.should == "TestTableScreen"
+  end
+  
+  it "should allow changing the tab bar item with set_tab_bar_item" do
+    @tab_1.set_tab_bar_item title: "Custom", icon: "test.jpeg"
+    @tab_bar.tabBar.items.first.title.should == "Custom"
+  end
+
+end
+
+


### PR DESCRIPTION
I know I said that we were in a feature freeze, but this is necessary
due to the on_load changes we made.

Plus:
- Moved module class method inclusions, made possible by loading
  ScreenModule in every Screen type. This is cleaner for class method
  inclusion, although there's still some room for improvement.
- Added unit tests for the tab bar and tab bar items
- Moved `on_init` after `screen_setup` which makes more sense.

Ref #216 

174 specifications (279 requirements), 0 failures, 0 errors
