### PR TITLE
Revert "fix section size from numberOfSectionsInTableView"

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -153,7 +153,7 @@ module ProMotion
 
     ########## Cocoa touch methods #################
     def numberOfSectionsInTableView(table_view)
-      return @promotion_table_data.data.size
+      return Array(@promotion_table_data.data).length
     end
 
     # Number of cells


### PR DESCRIPTION
Cause of #185 PR was due to RubyMotion's bug.
and It was fixed in RubyMotiom 2.4.

> RubyMotion 2.4 release notes (/Library/RubyMotion/NEWS)
> - Fixed a bug in Kernel#Array() where it would return an incorrected value
>   if an NSArray object was passed as argument.

I think good to revert #185 PR.
What do you think?
