### PR TITLE
bug fix: `update_table_data` raise error at `on_load`

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -60,6 +60,7 @@ module ProMotion
     end
 
     def update_table_view_data(data)
+      create_table_view_from_data(data) unless @promotion_table_data
       @promotion_table_data.data = data
       table_view.reloadData
     end

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -95,4 +95,21 @@ describe "table screens" do
 
   end
 
+  describe 'test PM::TableScreen\'s method call order' do
+    before do
+      class MethodCallOrderTestTableScreen < PM::TableScreen
+        def table_data; @table_data ||= []; end
+        def on_load
+          @table_data = [{cells: [ title: 'cell 1' ]}]
+          update_table_data
+        end
+      end
+    end
+
+    it 'should not raise error at load view' do
+      proc { @screen = MethodCallOrderTestTableScreen.new }.should.not.raise(NoMethodError)
+    end
+  end
+
 end
+


### PR DESCRIPTION
When I create simple table screen app, I encountered a bug.
Following code raise error:

``` ruby
class AppDelegate < PM::Delegate
  def on_load(application, options)
    open TestTableScreen
  end
end

class TestTableScreen < PM::TableScreen
  def table_data
    @table_data ||= []
  end

  def on_load
    @table_data = [{cells: [ {title: 'cell 1'} ] }]
    update_table_data
  end
end
```

This is almost same as documented code (https://github.com/clearsightstudio/ProMotion/wiki/API-Reference:-ProMotion::TableScreen#update_table_data).
And it output following error log.

```
Process motion-rake exited abnormally with code 1
     Build ./build/iPhoneSimulator-6.1-Development
  Simulate ./build/iPhoneSimulator-6.1-Development/pm-test.app
(main)> 2013-07-24 11:11:05.755 pm-test[5968:c07] table.rb:63:in `update_table_view_data:': undefined method `data=' for nil:NilClass (NoMethodError)
        from table.rb:151:in `update_table_data'
        from app_delegate.rb:14:in `on_load'
        from table_view_controller.rb:11:in `loadView'
        from table.rb:11:in `table_view'
        from table.rb:54:in `create_table_view_from_data:'
        from table.rb:34:in `set_up_table_view'
        from table.rb:24:in `screen_setup'
        from screen_module.rb:23:in `on_create:'
        from table_view_controller.rb:5:in `new:'
        from delegate_module.rb:55:in `open_screen:'
        from app_delegate.rb:3:in `on_load:'
        from delegate_module.rb:16:in `application:didFinishLaunchingWithOptions:'
2013-07-24 11:11:05.756 pm-test[5968:c07] *** Terminating app due to uncaught exception 'NoMethodError', reason: 'table.rb:63:in `update_table_view_data:': undefined method `data=' for nil:N\
ilClass (NoMethodError)
```

The reason of this bug, PM::TableScreen call some method in following call stack's order.

<pre>
`on_create`
  |_ `screen_setup`
         |_`set_up_table_view`
               |_ `create_table_view_from_data` : after processing this method, @promotion_table_data will be initialize
                       |_ `table_view` 
                              |_`loadView`
                                    |_`on_load`
                                          |_`update_table_data`  : @promotion_table_data == nil
</pre>


I fixed this bug by adding nil check at `update_table_view`.
Please, review my code!
