### PR TITLE
Fix a timing to create 'table_view' and call 'on_load'

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -31,6 +31,9 @@ module ProMotion
     end
 
     def set_up_table_view
+      # before access self.table_data, create UITableView and call on_load
+      table_view
+
       self.view = self.create_table_view_from_data(self.table_data)
     end
 


### PR DESCRIPTION
fixed rewrite table cells after called 'on_load'

I checked to all tests passed.
=> 225 specifications (391 requirements), 0 failures, 0 errors

sample code and flow.

``` ruby
class MyTableScreen < PM::TableScreen

  def on_load
    @table_data = [{
      title: 'new title',
      cells: [ #... ]
    }]

    update_table_data
  end

  def table_data
    # So hard to understand that it is empty,
    # changes default values.
    @table_data ||= [{ title: 'default_title', cells: [ #... ] }]
  end

end
```

```
`on_create`
|_`screen_setup`
  |_`set_up_table_view`
     |_`create_table_view_from_data` with `table_data`
        | `table_data` at this point ['table_data A']
        |  => [{ title: 'default_title', cells: [ #... ] }]
        |
        |_`table_view`
        |  |_`loadView`
        |    |_`on_load`
        |      | update `self.table_data`
        |      | `table_data` at this point ['table_data B']
        |      |  => [{ title: 'new title', cells: [ #... ] }]
        |      |
        |      |_`update_table_data`
        |        |_`update_table_view_data`
        |          | set @promotion_table_data.data at 'table_data B'
        |
        |_ `TableData.new` with 'table_data A'
          => rewrite @promotion_table_data at 'table_data A' from 'table_data B'
```

before:

``` ruby
def set_up_table_view
  # self.table_data #=> [{ title: 'default_title', cells: [ #... ] }]
  self.view = self.create_table_view_from_data(self.table_data)
end
```

after:

``` ruby
def set_up_table_view
  table_view # `table_view` > `loadView` > `on_load` > set new 'table_data'

  # self.table_data #=> [{ title: 'new title', cells: [ #... ] }]
  self.view = self.create_table_view_from_data(self.table_data)
end
```
