### PR TITLE
Fixes open in chrome functionality

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -101,6 +101,7 @@ module ProMotion
 
     def open_in_chrome(inRequest)
       # Add pod 'OpenInChrome' to your Rakefile if you want links to open in Google Chrome for users.
+      # This will fall back to Safari if the user doesn't have Chrome installed.
       chrome_controller = OpenInChromeController.sharedInstance
       return open_in_safari(inRequest) unless chrome_controller.isChromeInstalled
       chrome_controller.openInChrome(inRequest.URL)


### PR DESCRIPTION
Apparently, the OpenInChrome doesn't auto-translate to camelcase for their method signatures :P
