### PR TITLE
Allow MapScreen annotations to be images

### DIFF
--- a/lib/ProMotion/map/map_screen_annotation.rb
+++ b/lib/ProMotion/map/map_screen_annotation.rb
@@ -17,7 +17,7 @@ module ProMotion
       @params = {
         title: "Title",
         pin_color: MKPinAnnotationColorRed,
-        identifier: "Annotation-#{@params[:pin_color]}",
+        identifier: "Annotation-#{@params[:pin_color] || @params[:image]}",
         show_callout: true,
         animates_drop: false
       }.merge(@params)

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -100,12 +100,14 @@ module ProMotion
         view.annotation = annotation
       else
         #Set the pin properties
-        view = MKPinAnnotationView.alloc.initWithAnnotation(annotation, reuseIdentifier:identifier)
-        view.canShowCallout = annotation.annotation_params[:show_callout]
-        view.animatesDrop = annotation.annotation_params[:animates_drop]
         if annotation.annotation_params[:image]
+          view = MKAnnotationView.alloc.initWithAnnotation(annotation, reuseIdentifier:identifier)
+          view.canShowCallout = annotation.annotation_params[:show_callout]
           view.image =  annotation.annotation_params[:image]
         else
+          view = MKPinAnnotationView.alloc.initWithAnnotation(annotation, reuseIdentifier:identifier)
+          view.canShowCallout = annotation.annotation_params[:show_callout]
+          view.animatesDrop = annotation.annotation_params[:animates_drop]
           view.pinColor = annotation.annotation_params[:pin_color]
         end
       end


### PR DESCRIPTION
A very simple change that allows the use of `image` param in the MapScreen `annotation_data`

``` ruby
 def annotation_data
    [{
      longitude: -82.965972900391,
      latitude: 35.090648651123,
      title: "Rainbow Falls",
      subtitle: "Nantahala National Forest",
      image: "custom-pin".uiimage
    },{
      longitude: -82.966093558105,
      latitude: 35.092520895652,
      title: "Turtleback Falls",
      subtitle: "Nantahala National Forest",
      image: "custom-pin".uiimage
    }]
end
```
