### PR TITLE
Add support to application:openURL:sourceApplication:annotation

### DIFF
--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -38,6 +38,10 @@ module ProMotion
       on_unload if respond_to?(:on_unload)
     end
 
+    def application(application, openURL: url, sourceApplication:source_app, annotation: annotation)
+      on_open_url({ url: url, source_app: source_app, annotation: annotation }) if respond_to?(:on_open_url)
+    end
+
     def app_delegate
       self
     end

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -84,4 +84,17 @@ describe "PM::Delegate" do
     @subject.called_on_unload.should == true
   end
 
+  it "should handle open URL" do
+    url = NSURL.URLWithString("http://example.com")
+    sourceApplication = 'com.example'
+    annotation = {jamon: true}
+    @subject.mock!(:on_open_url) do |parameters|
+      parameters[:url].should == url
+      parameters[:source_app].should == sourceApplication
+      parameters[:annotation][:jamon].should.be.true
+    end
+
+    @subject.application(UIApplication.sharedApplication, openURL: url, sourceApplication:sourceApplication, annotation: annotation)
+  end
+
 end


### PR DESCRIPTION
Now you can use `on_open_url` instead.

http://developer.apple.com/library/ios/documentation/uikit/reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:openURL:sourceApplication:annotation:
