### PR TITLE
Added support for adding views using a Teacup stylename

### DIFF
--- a/lib/ProMotion/view/styling.rb
+++ b/lib/ProMotion/view/styling.rb
@@ -17,8 +17,8 @@ module ProMotion
         element.send("#{k}=", v)
       elsif v.is_a?(Array) && element.respond_to?("#{k}") && element.method("#{k}").arity == v.length
         element.send("#{k}", *v)
-      elsif k == :stylename && element.respond_to?(:apply_stylename)
-        element.apply_stylename(v.to_sym)
+      elsif k == :stylename && element.respond_to?(:style=)
+        element.style = v.to_sym
       else
         # Doesn't respond. Check if snake case.
         if k.to_s.include?("_")

--- a/spec/unit/screen_helpers_spec.rb
+++ b/spec/unit/screen_helpers_spec.rb
@@ -19,7 +19,7 @@ describe "screen helpers" do
     end
 
     it "should set attributes using :stylename before adding a subview" do
-      def @subview.apply_stylename(style); self.backgroundColor = UIColor.blueColor; end
+      def @subview.style=(style); self.backgroundColor = UIColor.blueColor; end
       @screen.add @subview, stylename: :subview_style
       @screen.view.subviews.first.backgroundColor.should == UIColor.blueColor
     end


### PR DESCRIPTION
As mentioned in #46, it looks like the option to add views using a Teacup stylename disappeared from the source.
I've added this back in, in the simplest and least obtrusive way I could think of. 

Any thoughts?
