### PR TITLE
Updating Tabs :icon attribute to accept UIImage

### DIFF
--- a/lib/ProMotion/containers/tabs.rb
+++ b/lib/ProMotion/containers/tabs.rb
@@ -35,8 +35,10 @@ module ProMotion
       return UITabBarItem.alloc.initWithTabBarSystemItem(icon, tag: tag)
     end
 
-    def create_tab_bar_icon_custom(title, image_name, tag)
-      icon_image = UIImage.imageNamed(image_name)
+    def create_tab_bar_icon_custom(title, icon_image, tag)
+      if icon_image.is_a?(String)
+        icon_image = UIImage.imageNamed(icon_image)
+      end
       return UITabBarItem.alloc.initWithTitle(title, image:icon_image, tag:tag)
     end
 


### PR DESCRIPTION
Hi,

I was trying to use ProMotion with FontAwesomeKit, a CocoaPod library that lets me use FontAwesome's icons throughout the application. However, when I wanted to use an icon for a tab, it would crash. Upon looking into it, it seems the assumption was made that the icon would be a name of a file, and automatically load / create a UIImage object.

For example:

``` ruby
  def on_load
    image = FontAwesomeKit.imageForIcon(FAKIconHeart, imageSize: CGSizeMake(30,30), fontSize: 29, attributes: nil)
    set_tab_bar_item icon: image
```

This (very small) patch detects if a string is passed in, and will create a UIImage. But if you pass an object in, it will use it instead. I think this is preferable behavior, as it does not change the interface for existing code, but enables folks to pass their own UIImage in for reasons like I described.

I didn't see any specs related to the "Tabs" container, or I would have added a test for this.

Let me know if you have any thoughts. Open to making a change.

Regards,
Daniel
