### PR TITLE
Add flat tabs

### DIFF
--- a/lib/ProMotion/containers/tabs.rb
+++ b/lib/ProMotion/containers/tabs.rb
@@ -38,8 +38,19 @@ module ProMotion
     def create_tab_bar_icon_custom(title, icon_image, tag)
       if icon_image.is_a?(String)
         icon_image = UIImage.imageNamed(icon_image)
+      elsif icon_image.is_a?(Hash)
+        icon_selected = icon_image[:selected]
+        icon_unselected = icon_image[:unselected]
+        icon_image = nil
       end
-      return UITabBarItem.alloc.initWithTitle(title, image:icon_image, tag:tag)
+      
+      item = UITabBarItem.alloc.initWithTitle(title, image:icon_image, tag:tag)
+
+      if icon_selected || icon_unselected
+        item.setFinishedSelectedImage(icon_selected, withFinishedUnselectedImage: icon_unselected)
+      end
+
+      return item
     end
 
     def create_tab_bar_item(tab={})


### PR DESCRIPTION
Adding the ability to customize tab icons further with selected and unselected states.

Again, I didn't change the API at all. You can now pass an icon in as a hash with `:selected` and `:unselected` states.

For example:

``` ruby
class BuddyScreen < PM::Screen
  def on_init
    icon = font_awesome_tab_icon(:group)
    set_tab_bar_item icon: {selected: icon, unselected: icon}, title: "Buddies"
  end
end
```

All previous icon types still work (strings for file names and UIImages for the default behavior).
