### PR TITLE
was_launched should return true when app is launched from background

### DIFF
--- a/lib/ProMotion/delegate/delegate_notifications.rb
+++ b/lib/ProMotion/delegate/delegate_notifications.rb
@@ -51,7 +51,7 @@ module ProMotion
     end
 
     def application(application, didReceiveRemoteNotification:notification)
-      received_push_notification(notification, false)
+      received_push_notification(notification, application.applicationState != UIApplicationStateActive)
     end
     
     protected

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -27,6 +27,35 @@ describe "PM::Delegate" do
 
   end
 
+  it "should return false for was_launched if the app is currently active on screen" do
+    @subject.mock!(:on_push_notification) do |notification, was_launched|
+      was_launched.should.be.false
+    end
+
+    UIApplication.sharedApplication.stub!(:applicationState, return: UIApplicationStateActive)
+    remote_notification = PM::PushNotification.fake_notification.notification
+    @subject.application(UIApplication.sharedApplication, didReceiveRemoteNotification: remote_notification)
+  end
+
+  it "should return true for was_launched if app was launched from background" do
+    @subject.mock!(:on_push_notification) do |notification, was_launched|
+      was_launched.should.be.true
+    end
+
+    UIApplication.sharedApplication.stub!(:applicationState, return: UIApplicationStateBackground)
+    remote_notification = PM::PushNotification.fake_notification.notification
+    @subject.application(UIApplication.sharedApplication, didReceiveRemoteNotification: remote_notification)
+  end
+
+  it "should return true for was_launched if the app wasn't running" do
+    @subject.mock!(:on_push_notification) do |notification, was_launched|
+      was_launched.should.be.true
+    end
+
+    launch_options = { UIApplicationLaunchOptionsRemoteNotificationKey => PM::PushNotification.fake_notification.notification }
+    @subject.application(UIApplication.sharedApplication, didFinishLaunchingWithOptions:launch_options )
+  end
+
   it "should set home_screen when opening a new screen" do
     @subject.application(UIApplication.sharedApplication, willFinishLaunchingWithOptions: nil)
     @subject.application(UIApplication.sharedApplication, didFinishLaunchingWithOptions: nil)


### PR DESCRIPTION
Possibly I'm not interpreting the `was_launched` variable the right way so correct me if I'm wrong! :laughing: 

It seems to me you would want `was_launched` to return `true` when clicking an incoming notification if the app is not already on screen, so you can properly handle for ex. sending the user to the correct screen when the app comes back on screen.

This pull request changes it so `was_launched` only returns `false` if the app is already on screen (and therefore "not launched") when the notification is received, and returns `true` whenever the app is brought on screen by clicking a notification.
