### PR TITLE
Add send_on_return callback to closing a modal.

### DIFF
--- a/lib/ProMotion/screen/screen_navigation.rb
+++ b/lib/ProMotion/screen/screen_navigation.rb
@@ -54,6 +54,7 @@ module ProMotion
 
       if self.modal?
         close_modal_screen args
+        send_on_return(args)
 
       elsif self.navigation_controller
         close_nav_screen args


### PR DESCRIPTION
When building my iPhone app using ProMotion, I've found it rather confusing as to why modals won't make a callback. Maybe it's designed like that, I'm not sure, but I think it is a useful thing to add.
