### PR TITLE
Add the ability to push a Screen on a navigation_controller without animation

### DIFF
--- a/lib/ProMotion/screen/screen_navigation.rb
+++ b/lib/ProMotion/screen/screen_navigation.rb
@@ -24,7 +24,7 @@ module ProMotion
         present_view_controller_in_tab_bar_controller screen, args[:in_tab]
 
       elsif self.navigation_controller
-        push_view_controller screen
+        push_view_controller(screen, nil, { animated: args[:animated] })
 
       else
         open_root_screen (screen.navigationController || screen)
@@ -76,14 +76,17 @@ module ProMotion
       end
     end
 
-    def push_view_controller(vc, nav_controller=nil)
+    def push_view_controller(vc, nav_controller = nil, args = {})
+      args ||= {}
+      args[:animated] = true unless args.has_key?(:animated)
+
       unless self.navigation_controller
         PM.logger.error "You need a nav_bar if you are going to push #{vc.to_s} onto it."
       end
       nav_controller ||= self.navigation_controller
       vc.first_screen = false if vc.respond_to?(:first_screen=)
       vc.navigation_controller = nav_controller if vc.respond_to?(:navigation_controller=)
-      nav_controller.pushViewController(vc, animated: true)
+      nav_controller.pushViewController(vc, animated: args[:animated])
     end
 
     protected

--- a/spec/unit/screen_helpers_spec.rb
+++ b/spec/unit/screen_helpers_spec.rb
@@ -106,13 +106,13 @@ describe "screen helpers" do
 
     it "#push_view_controller should use the default navigation controller if not provided" do
       vcs = @screen.navigation_controller.viewControllers
-      @screen.push_view_controller @second_vc
+      @screen.push_view_controller(@second_vc, @screen.navigation_controller)
       @screen.navigation_controller.viewControllers.count.should == vcs.count + 1
     end
 
     it "#push_view_controller should use a provided navigation controller" do
       second_nav_controller = UINavigationController.alloc.initWithRootViewController @screen
-      @screen.push_view_controller @second_vc, second_nav_controller
+      @screen.push_view_controller(@second_vc, second_nav_controller)
       second_nav_controller.viewControllers.count.should == 2
     end
 
@@ -202,8 +202,22 @@ describe "screen helpers" do
       end
 
       it "should pop onto navigation controller if current screen is on nav stack already" do
-        @screen.mock!(:push_view_controller) { |vc| vc.should.be.instance_of BasicScreen }
+        @screen.mock!(:push_view_controller) do |vc, nav_controller, args|
+          vc.should.be.instance_of BasicScreen
+          nav_controller.should == nil
+          args.should == { animated: true }
+        end
         screen = @screen.open BasicScreen
+        screen.should.be.kind_of BasicScreen
+      end
+
+      it "should pop onto navigation controller if current screen is on nav stack already without animation" do
+        @screen.mock!(:push_view_controller) do |vc, nav_controller, args|
+          vc.should.be.instance_of BasicScreen
+          nav_controller.should == nil
+          args.should == { animated: false }
+        end
+        screen = @screen.open(BasicScreen, animated: false)
         screen.should.be.kind_of BasicScreen
       end
 


### PR DESCRIPTION
Hi,

I've added the ability to push a screen on a navigation_controller without animation.

Example:

```
open_screen(MyScreen, { animated: false }
```

Tests are ok, and here is the result for my changes.

```
bundle exec rake spec files=spec/unit/screen_helpers_spec.rb
34 specifications (62 requirements), 0 failures, 0 errors
```
