### PR TITLE
Allow users to specify their own nib and bundle names.

### DIFF
--- a/lib/ProMotion/cocoatouch/view_controller.rb
+++ b/lib/ProMotion/cocoatouch/view_controller.rb
@@ -1,11 +1,11 @@
 module ProMotion
   class ViewController < UIViewController
     def self.new(args = {})
-      s = self.alloc.initWithNibName(nil, bundle:nil)
+      s = self.alloc.initWithNibName(args[:nib_name] || nil, bundle:args[:bundle] || nil)
       s.on_create(args) if s.respond_to?(:on_create)
       s
     end
-    
+
     def loadView
       super
       self.send(:on_load) if self.respond_to?(:on_load)


### PR DESCRIPTION
This is preliminary support for the [`ib`](https://github.com/yury/ib) gem.  I have [an outstanding pr](https://github.com/yury/ib/pull/45) that fixes their side of generating the xcode stub files for promotion.

You can create an XIB file and initialize it like so:

``` ruby
my_cool_screen = CoolScreen.new(nav_bar: true, nib_name:"CoolScreen")
```

I'm wondering if there's a smarter way to do this like search the bundle path for an interface file named `PMScreenSubclassName.xib` and auto-load it if it exists.
