### PR TITLE
Added an option to disable the 'swipe to open split screen'

### DIFF
--- a/lib/ProMotion/containers/split_screen.rb
+++ b/lib/ProMotion/containers/split_screen.rb
@@ -26,6 +26,10 @@ module ProMotion
         @button_title = args[:button_title]
       end
 
+      if args.has_key?(:swipe)
+        split.presentsWithGesture = args[:swipe]
+      end
+
       split
     end
 

--- a/spec/functional/func_split_screen_spec.rb
+++ b/spec/functional/func_split_screen_spec.rb
@@ -71,4 +71,11 @@ describe "Split screen functional" do
     @detail.navigationItem.leftBarButtonItem.title.should == test_title
   end
 
+  it "should override the default swipe action, that reveals the menu" do
+    rotate_device to: :portrait, button: :bottom
+
+    @controller = @app.open_split_screen @master, @detail, swipe: false
+    @app.home_screen.presentsWithGesture.should == false
+  end
+
 end


### PR DESCRIPTION
Hi,

There was no option to disable the default swipe action for the splitViewController, so I've added this to the controller. Also wrote a test for it, that passed.

Cheers.
