### PR TITLE
Correct git url for cloning default template

### DIFF
--- a/bin/promotion
+++ b/bin/promotion
@@ -31,7 +31,7 @@ class App
   def self.create(name)
     return puts "Usage: promotion new <appname>" unless name.to_s.length > 0
     info "Creating new ProMotion iOS app #{name}"
-    sh "motion create --template=git@github.com:jamonholmgren/promotion-template.git #{name}"
+    sh "motion create --template=git://github.com/jamonholmgren/promotion-template.git #{name}"
   end
 
   description "Command line for ProMotion."


### PR DESCRIPTION
The SSH URL for accessing a git repo is only usable if you have push access to that repo. Changing it to a public form of the url makes it work.
