### PR TITLE
Add a content_width helper (similar to content_height)

### DIFF
--- a/lib/ProMotion/view/styling.rb
+++ b/lib/ProMotion/view/styling.rb
@@ -47,17 +47,28 @@ module ProMotion
       element
     end
 
-    def content_height(view)
-      height = 0
-      view.subviews.each do |sub_view|
-        next if sub_view.isHidden
-        y = sub_view.frame.origin.y
-        h = sub_view.frame.size.height
-        if (y + h) > height
-          height = y + h
+    def content_max(view, mode = :height)
+      return 0 if view.subviews.empty?
+
+      sizes = view.subviews.map do |sub_view|
+        if sub_view.isHidden
+          0
+        elsif mode == :height
+          sub_view.frame.origin.y + sub_view.frame.size.height
+        else
+          sub_view.frame.origin.x + sub_view.frame.size.width
         end
       end
-      height
+
+      sizes.max
+    end
+
+    def content_height(view)
+      content_max(view, :height)
+    end
+
+    def content_width(view)
+      content_max(view, :width)
     end
 
     def closest_parent(type, this_view = nil)

--- a/spec/unit/view_helper_spec.rb
+++ b/spec/unit/view_helper_spec.rb
@@ -56,20 +56,37 @@ describe "view helpers" do
   end
 
 
-  describe "content height" do
+  context "content sizing" do
 
     before do
       @child = UIView.alloc.initWithFrame([[20,100],[300,380]])
       @dummy.addSubview @child
     end
 
-    it "should return content height" do
-      @dummy.content_height(@dummy).should == 480
+    describe "content_height" do
+
+      it "should return content height" do
+        @dummy.content_height(@dummy).should == 480
+      end
+
+      it "should ignore hidden subviews" do
+        @child.hidden = true
+        @dummy.content_height(@dummy).should == 0
+      end
+
     end
 
-    it "should ignore hidden subviews" do
-      @child.hidden = true
-      @dummy.content_height(@dummy).should == 0
+    describe "content_width" do
+
+      it "should return content width" do
+        @dummy.content_width(@dummy).should == 320
+      end
+
+      it "should ignore hidden subviews" do
+        @child.hidden = true
+        @dummy.content_width(@dummy).should == 0
+      end
+
     end
 
   end


### PR DESCRIPTION
For horizontally-scrolling views, a `content_width` helper would be pretty useful. I added it, and made both `content_width` and `content_height` delegate to a `content_size` method instead to avoid duplicated code.

I also refactored the calculations a bit (mapping all of the subviews' dimensions and pulling the max value).

If anyone has a better name than `content_size` (which might easily be confused with `contentSize`), I can definitely change it. Maybe `content_dimension`?
