### PR TITLE
re-bind submit after update_table_data is called

### DIFF
--- a/lib/ProMotion/thirdparty/formotion_screen.rb
+++ b/lib/ProMotion/thirdparty/formotion_screen.rb
@@ -19,9 +19,13 @@ module ProMotion
         s.tableView.allowsSelectionDuringEditing = true
         s.title = t
 
-        s.form.on_submit { |form| s.on_submit(form) if s.respond_to?(:on_submit) }
+        s.bind_submit
 
         s
+      end
+
+      def bind_submit
+        self.form.on_submit { |form| self.on_submit(form) if self.respond_to?(:on_submit) }
       end
 
       # emulate the ProMotion table update for formotion
@@ -29,6 +33,7 @@ module ProMotion
         self.form            = table_data
         self.form.controller = self
         self.tableView.reloadData
+        self.bind_submit
       end
 
       def screen_setup

--- a/spec/helpers/table_screen_formotion.rb
+++ b/spec/helpers/table_screen_formotion.rb
@@ -4,7 +4,7 @@ class TestFormotionScreen < PM::FormotionScreen
   title "Formotion Test"
 
   def table_data
-    @data ||= {
+    @table_data ||= {
       sections: [{
         title: "Currency",
         key: :currency,
@@ -27,4 +27,24 @@ class TestFormotionScreen < PM::FormotionScreen
     self.submitted_form = form
   end
 
+  def test_update_table_data
+    @table_data = {
+      sections: [{
+        title: "Updated Data",
+        key: :currency,
+        select_one: true,
+        rows: [{
+          title: "EUR",
+          key: :eur,
+          value: true,
+          type: :check
+        }, {
+          title: "USD",
+          key: :usd,
+          type: :check
+        }]
+      }]
+    }
+    update_table_data
+  end
 end

--- a/spec/unit/tables/formotion_screen_spec.rb
+++ b/spec/unit/tables/formotion_screen_spec.rb
@@ -19,4 +19,19 @@ describe "PM::FormotionScreen" do
     @screen.submitted_form.render.should.be.kind_of(Hash)
   end
 
+  describe "After update_table_data" do
+    before do
+      @screen.test_update_table_data
+    end
+
+    it "should update the table data" do
+      @screen.table_data[:sections][0][:title].should == "Updated Data"
+    end
+
+    it "should fire the on_submit method when form is submitted" do
+      @screen.form.submit
+      @screen.submitted_form.should.not.be.nil
+      @screen.submitted_form.render.should.be.kind_of(Hash)
+    end
+  end
 end


### PR DESCRIPTION
When calling update_table_data, Formotion submit buttons added in the new data do not fire the on_submit action. This commit adds a fix and tests.

eg.

``` ruby
class SomeFormScreen < PM::FormotionScreen
  def table_data
    @table_data ||= {}
  end

  def on_load
    @table_data = {
      sections: [
        {
          title: 'My Test Form'
          rows: [{
            title: "Update",
            type: :submit
          }]
        }
      ]
    }
    update_table_data
  end

  def on_submit(_form)
    # Does not fire
    PM.logger.debug('Fires')
  end
end
```
