### PR TITLE
preserves title after update_table_data

### DIFF
--- a/lib/ProMotion/thirdparty/formotion_screen.rb
+++ b/lib/ProMotion/thirdparty/formotion_screen.rb
@@ -15,17 +15,10 @@ module ProMotion
           PM.logger.error "PM::FormotionScreen requires a `table_data` method or form: to be passed into `new`."
         end
 
-        t = s.title # Formotion kills the title when you request tableView.
         s.tableView.allowsSelectionDuringEditing = true
-        s.title = t
-
-        s.bind_submit
+        s.after_setup
 
         s
-      end
-
-      def bind_submit
-        self.form.on_submit { |form| self.on_submit(form) if self.respond_to?(:on_submit) }
       end
 
       # emulate the ProMotion table update for formotion
@@ -33,11 +26,20 @@ module ProMotion
         self.form            = table_data
         self.form.controller = self
         self.tableView.reloadData
-        self.bind_submit
+        self.after_setup
       end
 
       def screen_setup
         self.title = self.class.send(:get_title)
+      end
+
+      def after_setup
+        self.title = self.class.send(:get_title) # Formotion kills the title when you request tableView.
+        self.bind_submit # bind submit action after populating table data
+      end
+
+      def bind_submit
+        self.form.on_submit { |form| self.on_submit(form) if self.respond_to?(:on_submit) }
       end
 
       def loadView

--- a/spec/unit/tables/formotion_screen_spec.rb
+++ b/spec/unit/tables/formotion_screen_spec.rb
@@ -24,6 +24,10 @@ describe "PM::FormotionScreen" do
       @screen.test_update_table_data
     end
 
+    it "should preserve the screen title" do
+      @screen.title.should == "Formotion Test"
+    end
+
     it "should update the table data" do
       @screen.table_data[:sections][0][:title].should == "Updated Data"
     end


### PR DESCRIPTION
Just caught that the title was also getting squashed when calling `update_table_data`. I refactored the existing method to preserve the title, and moved that and and the bind_submit method into an `after_setup` method.

``` ruby
def after_setup
  self.title = self.class.send(:get_title) # Formotion kills the title when you request tableView.
  self.bind_submit # bind submit action after populating table data
end
```

 I would have liked to move `bind_submit` into the `screen_setup` method for clarity, and because it already sets the title, but since that's actually a hook into `ScreenModule#on_create` it gets called before a form exists and is thus useless for initial setup. 

It's also worth noting that `screen_setup` is basically worthless here because simply calling `tableView` kills what it does anyway.

``` ruby
def screen_setup
  # killed by formotion_screen.rb#18  s.tableView.allowsSelectionDuringEditing = true
  self.title = self.class.send(:get_title)
end
```
