### PR TITLE
Added warning on erroneous styling methods (if log level is high enough)

### DIFF
--- a/lib/ProMotion/view/styling.rb
+++ b/lib/ProMotion/view/styling.rb
@@ -24,6 +24,9 @@ module ProMotion
         # Doesn't respond. Check if snake case.
         if k.to_s.include?("_")
           set_attribute(element, objective_c_method_name(k), v)
+        else
+          # Warn
+          PM.logger.warn("set_attribute: #{element.inspect} doesn't respond to `#{k.to_s}` or `#{k.to_s}=`.")
         end
       end
       element


### PR DESCRIPTION
I'd like to see a warning in the REPL if I'm trying to set an attribute that the object doesn't respond to.

![warn](http://media.clearsightstudio.com/jamon/1._bundled_rake_ruby_20140116_210948.jpg)

However, this will expose some inefficiencies in ProMotion, so we should be prepared to deal with those. For example, PM::TableScreen carelessly applies a lot of attributes to cells that it shouldn't:

![overwarn](http://media.clearsightstudio.com/jamon/1._bundled_rake_ruby_20140116_211112.jpg)

Feedback welcome.
