### PR TITLE
Add default return value for application willFinishLaunchingWithOptions

### DIFF
--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -8,6 +8,7 @@ module ProMotion
 
     def application(application, willFinishLaunchingWithOptions:launch_options)
       will_load(application, launch_options) if respond_to?(:will_load)
+      true
     end
 
     def application(application, didFinishLaunchingWithOptions:launch_options)


### PR DESCRIPTION
The return value is necessary to be able to use openURL because this callback is only called if willFinishLaunchingWithOptions and didFinishLaunchingWithOptions return true. See: http://goo.gl/Q0OQBF
