### PR TITLE
Apply styles to default IULabels

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -57,6 +57,11 @@ module ProMotion
         end
         self.detailTextLabel.backgroundColor = UIColor.clearColor
         self.detailTextLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth
+
+        if data_cell[:styles] && data_cell[:styles][:subtitle]
+          set_attributes self.detailTextLabel, data_cell[:styles][:subtitle]
+        end
+
       end
       self
     end
@@ -143,6 +148,10 @@ module ProMotion
           self.textLabel.attributedText = cell_title
         else
           self.textLabel.text = cell_title
+        end
+
+        if data_cell[:styles] && data_cell[:styles][:label]
+          set_attributes self.textLabel, data_cell[:styles][:label]
         end
       end
 

--- a/spec/unit/tables/table_view_cell_spec.rb
+++ b/spec/unit/tables/table_view_cell_spec.rb
@@ -27,6 +27,24 @@ describe "PM::TableViewCellModule" do
     }
   end
 
+  def styled_cell_labels
+    {
+      title: "Styled Main Label",
+      subtitle: "Styled Subtitle Label",
+      cell_style: UITableViewCellStyleSubtitle,
+      styles: {
+        label: {
+          textAlignment: NSTextAlignmentCenter,
+          textColor: UIColor.blueColor
+        },
+        subtitle: {
+          textAlignment: NSTextAlignmentRight,
+          textColor: UIColor.redColor
+        }
+      }
+    }
+  end
+
   before do
     @screen = TestTableScreen.new
     button = UIButton.buttonWithType(UIButtonTypeRoundedRect).tap{|b| b.titleLabel.text = "ACC" }
@@ -41,7 +59,8 @@ describe "PM::TableViewCellModule" do
             { title: "Test 1", accessory_type: UITableViewCellStateShowingEditControlMask },
             custom_cell,
             { title: "Test2", accessory: { view: button } },
-            attributed_cell
+            attributed_cell,
+            styled_cell_labels
           ]
         }
       ]
@@ -51,11 +70,13 @@ describe "PM::TableViewCellModule" do
 
     @custom_ip = NSIndexPath.indexPathForRow(1, inSection: 1) # Cell "Crazy Full Featured Cell"
     @attributed_ip = NSIndexPath.indexPathForRow(3, inSection: 1) # Attributed Cell
+    @styled_ip = NSIndexPath.indexPathForRow(4, inSection: 1)
 
     @screen.update_table_data
 
     @subject = @screen.tableView(@screen.table_view, cellForRowAtIndexPath: @custom_ip)
     @attributed_subject = @screen.tableView(@screen.table_view, cellForRowAtIndexPath: @attributed_ip)
+    @styled_subject = @screen.tableView(@screen.table_view, cellForRowAtIndexPath: @styled_ip)
   end
 
   it "should be a PM::TableViewCell" do
@@ -134,7 +155,15 @@ describe "PM::TableViewCellModule" do
     content_view.subviews[2].class.should == UILabel
   end
 
+  it "should allow styled title" do
+    @styled_subject.textLabel.textColor.should == UIColor.blueColor
+    @styled_subject.textLabel.textAlignment.should == NSTextAlignmentCenter
+  end
 
+  it "should allow styled subtitle" do
+    @styled_subject.detailTextLabel.textColor.should == UIColor.redColor
+    @styled_subject.detailTextLabel.textAlignment.should == NSTextAlignmentRight
+  end
 
 end
 


### PR DESCRIPTION
This changes allow for properties in the main `textLabel` and `detailTextLabel` to be set from the `styles` hash in each cell.

This was possible to do with attributed strings but I think this is easier for some common attributes.

I added the code where I thought made more sense, but as line 11 says, this file probably needs some deeper house cleaning :)
