### PR TITLE
fix UITableViewCells with height 0 still showing contents in iOS 7.1

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -139,6 +139,7 @@ module ProMotion
         table_cell = data_cell[:cell_class].alloc.initWithStyle(data_cell[:cell_style], reuseIdentifier:data_cell[:cell_identifier])
         table_cell.extend PM::TableViewCellModule unless table_cell.is_a?(PM::TableViewCellModule)
         table_cell.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleRightMargin
+        table_cell.clipsToBounds = true # fix for changed default in 7.1
       end
 
       table_cell.setup(data_cell, self)


### PR DESCRIPTION
default seems to have changed in 7.1 to NO, which causes collapsed cells to still show contents
