### PR TITLE
Set webView Deceleration for smooth scrolling

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -23,7 +23,7 @@ module ProMotion
         delegate: self,
         data_detector_types: self.detector_types
       }
-
+      self.webview.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
       set_initial_content
     end
 


### PR DESCRIPTION
Setting the webview's scrollview deacceleration rate to normal to enable smooth scrolling, to match 'normal' iOS scrollviews. This is a better experience, makes the webview act 'more native'. 
