### PR TITLE
Refactor/table view cell cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ProMotion (2.0.0)
       dbt (~> 1.1.4)
-      methadone (~> 1.3)
+      methadone (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +13,7 @@ GEM
       bundler
     motion-redgreen (0.1.0)
     motion-stump (0.3.2)
-    rake (10.3.1)
+    rake (10.3.2)
     webstub (1.0.1)
 
 PLATFORMS
@@ -23,5 +23,5 @@ DEPENDENCIES
   ProMotion!
   motion-redgreen (~> 0.1)
   motion-stump (~> 0.3)
-  rake (~> 10.1)
+  rake (>= 10.0)
   webstub (~> 1.0)

--- a/ProMotion.gemspec
+++ b/ProMotion.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |gem|
   gem.version       = ProMotion::VERSION
 
   gem.add_dependency "dbt", "~> 1.1.4"
-  gem.add_runtime_dependency("methadone", "~> 1.3")
+  gem.add_runtime_dependency("methadone", "~> 1.4")
   gem.add_development_dependency("webstub", "~> 1.0")
   gem.add_development_dependency("motion-stump", "~> 0.3")
   gem.add_development_dependency("motion-redgreen", "~> 0.1")
-  gem.add_development_dependency("rake", "~> 10.1")
+  gem.add_development_dependency("rake", ">= 10.0")
 end

--- a/app/test_screens/table_screen.rb
+++ b/app/test_screens/table_screen.rb
@@ -39,10 +39,10 @@ class TestTableScreen < ProMotion::TableScreen
       cells: [{
         title: "Switch With Action",
         accessory: {
-            view: :switch,
-            action: :increment_counter,
-            accessibility_label: "switch_1"
-          } ,
+          view: :switch,
+          action: :increment_counter,
+          accessibility_label: "switch_1"
+        },
       }, {
         title: "Switch With Action And Parameters",
         accessory: {
@@ -50,7 +50,7 @@ class TestTableScreen < ProMotion::TableScreen
           action: :increment_counter_by,
           arguments: { number: 3 },
           accessibility_label: "switch_2"
-        } ,
+        },
       }, {
         title: "Switch With Cell Tap, Switch Action And Parameters",
         accessory:{

--- a/lib/ProMotion/cocoatouch/ns_string.rb
+++ b/lib/ProMotion/cocoatouch/ns_string.rb
@@ -1,0 +1,5 @@
+class NSString
+  def to_url
+    NSURL.URLWithString(self)
+  end
+end

--- a/lib/ProMotion/cocoatouch/ns_url.rb
+++ b/lib/ProMotion/cocoatouch/ns_url.rb
@@ -1,0 +1,5 @@
+class NSURL
+  def to_url
+    self
+  end
+end

--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -9,163 +9,104 @@ module ProMotion
       self.table_screen = WeakRef.new(screen)
       self.data_cell = data_cell
 
-      # TODO: Some of these need to go away. Unnecessary overhead.
-      set_cell_attributes
-      set_accessory_view
+      set_styles
+      set_title
       set_subtitle
       set_image
       set_remote_image
-      set_subviews
-      set_details
-      set_styles
+      set_accessory_view
       set_selection_style
-
-      self
     end
 
-    def set_cell_attributes
-      data_cell_attributes = data_cell.dup
-      [:image, :accessory_action, :editing_style].each { |k| data_cell_attributes.delete(k) }
-      set_attributes self, data_cell_attributes
-      self
+  protected
+
+    def set_styles
+      set_attributes self, data_cell[:style] if data_cell[:style]
     end
 
-    def set_accessory_view
-      if data_cell[:accessory]
-        if data_cell[:accessory][:view] == :switch
-          switch_view = UISwitch.alloc.initWithFrame(CGRectZero)
-          switch_view.setAccessibilityLabel(data_cell[:accessory][:accessibility_label] || data_cell[:title])
-          switch_view.addTarget(self.table_screen, action: "accessory_toggled_switch:", forControlEvents:UIControlEventValueChanged)
-          switch_view.on = !!data_cell[:accessory][:value]
-          self.accessoryView = switch_view
-        elsif data_cell[:accessory][:view]
-          self.accessoryView = data_cell[:accessory][:view]
-          self.accessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth
-        end
-      else
-        self.accessoryView = nil
-      end
-
-      self
+    def set_title
+      set_attributed_text(self.textLabel, data_cell[:title])
     end
 
     def set_subtitle
-      if data_cell[:subtitle] && self.detailTextLabel
-        if data_cell[:subtitle].is_a? NSAttributedString
-          self.detailTextLabel.attributedText = data_cell[:subtitle]
-        else
-          self.detailTextLabel.text = data_cell[:subtitle]
-        end
-        self.detailTextLabel.backgroundColor = UIColor.clearColor
-        self.detailTextLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth
-      end
-      self
+      return unless data_cell[:subtitle] && self.detailTextLabel
+      set_attributed_text(self.detailTextLabel, data_cell[:subtitle])
+      self.detailTextLabel.backgroundColor = UIColor.clearColor
+      self.detailTextLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth
     end
 
     def set_remote_image
-      if data_cell[:remote_image]
-        if self.imageView.respond_to?("setImageWithURL:placeholder:")
-          url = data_cell[:remote_image][:url]
-          url = NSURL.URLWithString(url) unless url.is_a?(NSURL)
-          placeholder = data_cell[:remote_image][:placeholder]
-          placeholder = UIImage.imageNamed(placeholder) if placeholder.is_a?(String)
-
-          self.image_size = data_cell[:remote_image][:size] if data_cell[:remote_image][:size] && self.respond_to?("image_size=")
-          self.imageView.setImageWithURL(url, placeholder: placeholder)
-          self.imageView.layer.masksToBounds = true
-          self.imageView.layer.cornerRadius = data_cell[:remote_image][:radius] if data_cell[:remote_image].has_key?(:radius)
-          self.imageView.contentMode = map_content_mode_symbol(data_cell[:remote_image][:content_mode]) if data_cell[:remote_image].has_key?(:content_mode)
-        elsif self.imageView.respond_to?("setImageWithURL:placeholderImage:")
-          # TODO - Remove this in next major release
-          PM.logger.deprecated "The SDWebImage cocoapod is deprecated. Please replace it with 'JMImageCache'."
-        else
-          PM.logger.error "ProMotion Warning: to use remote_image with TableScreen you need to include the CocoaPod 'JMImageCache'."
-        end
-      end
-      self
+      return unless data_cell[:remote_image] && jm_image_cache?
+      self.image_size = data_cell[:remote_image][:size] if data_cell[:remote_image][:size] && self.respond_to?("image_size=")
+      self.imageView.setImageWithURL(data_cell[:remote_image][:url].to_url, placeholder: remote_placeholder)
+      self.imageView.layer.masksToBounds = true
+      self.imageView.layer.cornerRadius = data_cell[:remote_image][:radius] if data_cell[:remote_image][:radius]
+      self.imageView.contentMode = map_content_mode_symbol(data_cell[:remote_image][:content_mode]) if data_cell[:remote_image][:content_mode]
     end
 
     def set_image
-      if data_cell[:image]
-
-        cell_image = data_cell[:image].is_a?(Hash) ? data_cell[:image][:image] : data_cell[:image]
-        cell_image = UIImage.imageNamed(cell_image) if cell_image.is_a?(String)
-
-        self.imageView.layer.masksToBounds = true
-        self.imageView.image = cell_image
-        self.imageView.layer.cornerRadius = data_cell[:image][:radius] if data_cell[:image].is_a?(Hash) && data_cell[:image][:radius]
-      end
-      self
+      return unless data_cell[:image]
+      cell_image = data_cell[:image].is_a?(Hash) ? data_cell[:image][:image] : data_cell[:image]
+      cell_image = UIImage.imageNamed(cell_image) if cell_image.is_a?(String)
+      self.imageView.layer.masksToBounds = true
+      self.imageView.image = cell_image
+      self.imageView.layer.cornerRadius = data_cell[:image][:radius] if data_cell[:image].is_a?(Hash) && data_cell[:image][:radius]
     end
 
-    def set_subviews
-      tag_number = 0
-      Array(data_cell[:subviews]).each do |view|
-        # Remove an existing view at that tag number
-        tag_number += 1
-        existing_view = self.viewWithTag(tag_number)
-        existing_view.removeFromSuperview if existing_view
-
-        # Add the subview if it exists
-        if view
-          view.tag = tag_number
-          self.addSubview view
-        end
-      end
-      self
-    end
-
-    def set_details
-      if data_cell[:details]
-        self.addSubview data_cell[:details][:image]
-      end
-      self
-    end
-
-    def set_styles
-      if data_cell[:styles] && data_cell[:styles][:label] && data_cell[:styles][:label][:frame]
-        ui_label = false
-        self.contentView.subviews.each do |view|
-          if view.is_a? UILabel
-            ui_label = true
-            view.text = data_cell[:styles][:label][:text]
-          end
-        end
-
-        unless ui_label == true
-          label ||= UILabel.alloc.initWithFrame(CGRectZero)
-          set_attributes label, data_cell[:styles][:label]
-          self.contentView.addSubview label
-        end
-
-        # TODO: What is this and why is it necessary?
-        self.textLabel.textColor = UIColor.clearColor
+    def set_accessory_view
+      return self.accessoryView = nil unless data_cell[:accessory] && data_cell[:accessory][:view]
+      if data_cell[:accessory][:view] == :switch
+        self.accessoryView = switch_view
       else
-        cell_title = data_cell[:title]
-        cell_title ||= ""
-        self.textLabel.backgroundColor = UIColor.clearColor
-        if cell_title.is_a? NSAttributedString
-          self.textLabel.attributedText = cell_title
-        else
-          self.textLabel.text = cell_title
-        end
+        self.accessoryView = data_cell[:accessory][:view]
+        self.accessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth
       end
-
-      self
     end
 
     def set_selection_style
-      self.selectionStyle = UITableViewCellSelectionStyleNone if data_cell[:no_select]
+      self.selectionStyle = map_selection_style_symbol(data_cell[:selection_style]) if data_cell[:selection_style]
+    end
+
+  private
+
+    def jm_image_cache?
+      return true if self.imageView.respond_to?("setImageWithURL:placeholder:")
+      PM.logger.error "ProMotion Warning: to use remote_image with TableScreen you need to include the CocoaPod 'JMImageCache'."
+      false
+    end
+
+    def remote_placeholder
+      UIImage.imageNamed(data_cell[:remote_image][:placeholder]) if data_cell[:remote_image][:placeholder].is_a?(String)
+    end
+
+    def switch_view
+      switch = UISwitch.alloc.initWithFrame(CGRectZero)
+      switch.setAccessibilityLabel(data_cell[:accessory][:accessibility_label] || data_cell[:title])
+      switch.addTarget(self.table_screen, action: "accessory_toggled_switch:", forControlEvents:UIControlEventValueChanged)
+      switch.on = !!data_cell[:accessory][:value]
+      switch
+    end
+
+    def set_attributed_text(label, text)
+      text.is_a?(NSAttributedString) ? label.attributedText = text : label.text = text
     end
 
     def map_content_mode_symbol(symbol)
-      content_mode = {
+      {
         scale_to_fill:     UIViewContentModeScaleToFill,
         scale_aspect_fit:  UIViewContentModeScaleAspectFit,
         scale_aspect_fill: UIViewContentModeScaleAspectFill,
         mode_redraw:       UIViewContentModeRedraw
-      }[symbol] if symbol.is_a?(Symbol)
-      content_mode || symbol
+      }[symbol] || symbol
+    end
+
+    def map_selection_style_symbol(symbol)
+      {
+        none:     UITableViewCellSelectionStyleNone,
+        blue:     UITableViewCellSelectionStyleBlue,
+        gray:     UITableViewCellSelectionStyleGray,
+        default:  UITableViewCellSelectionStyleDefault
+      }[symbol] || symbol
     end
   end
 end

--- a/spec/functional/func_split_screen_spec.rb
+++ b/spec/functional/func_split_screen_spec.rb
@@ -67,14 +67,14 @@ describe "Split screen functional" do
     rotate_device to: :portrait, button: :bottom
 
     test_title = "Test Title"
-    @controller = @app.open_split_screen @master, @detail, button_title: test_title
+    @alt_controller = @app.open_split_screen @master, @detail, button_title: test_title
     @detail.navigationItem.leftBarButtonItem.title.should == test_title
   end
 
   it "should override the default swipe action, that reveals the menu" do
     rotate_device to: :portrait, button: :bottom
 
-    @controller = @app.open_split_screen @master, @detail, swipe: false
+    @alt_controller = @app.open_split_screen @master, @detail, swipe: false
     @app.home_screen.presentsWithGesture.should == false
   end
 

--- a/spec/functional/func_table_screen_spec.rb
+++ b/spec/functional/func_table_screen_spec.rb
@@ -92,34 +92,33 @@ describe "ProMotion::TestTableScreen functionality" do
     end
   end
 
-  # Disabled by Jamon 10/16/2013 -- Bacon doesn't appear to use accessibility labels?
   it "should call a method when the switch is flipped" do
-  #   @controller.scroll_to_bottom
-  #   tap "switch_1"
-  #   wait 0.3 do
-  #     @controller.tap_counter.should == 1
-  #   end
+    @controller.scroll_to_bottom
+    tap "switch_1"
+    wait 0.3 do
+      @controller.tap_counter.should == 1
+    end
   end
 
   it "should call the method with arguments when the switch is flipped and when the cell is tapped" do
-  #   @controller.scroll_to_bottom
-  #   tap "switch_3"
-  #   wait 0.3 do
-  #     @controller.tap_counter.should == 3
+    @controller.scroll_to_bottom
+    tap "switch_3"
+    wait 0.3 do
+      @controller.tap_counter.should == 3
 
-  #     tap "Switch With Cell Tap, Switch Action And Parameters"
-  #     wait 0.3 do
-  #       @controller.tap_counter.should == 13
-  #     end
-  #   end
+      tap "Switch With Cell Tap, Switch Action And Parameters"
+      wait 0.3 do
+        @controller.tap_counter.should == 13
+      end
+    end
   end
 
   it "should call the method with arguments when the switch is flipped" do
-  #   @controller.scroll_to_bottom
-  #   tap "switch_2"
-  #   wait 0.3 do
-  #     @controller.tap_counter.should == 3
-  #   end
+    @controller.scroll_to_bottom
+    tap "switch_2"
+    wait 0.3 do
+      @controller.tap_counter.should == 3
+    end
   end
 
 end

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -15,20 +15,23 @@ describe "PM::Table module" do
       cell_style: UITableViewCellStyleSubtitle,
       cell_identifier: "Cell",
       cell_class: PM::TableViewCell,
-      masks_to_bounds: true,
-      background_color: UIColor.colorWithPatternImage(@image),
-      selection_style: UITableViewCellSelectionStyleGray,
+      selection_style: :gray,
       accessory: {
         view: :switch, # currently only :switch is supported
         type: UITableViewCellAccessoryCheckmark,
-        checked: true # whether it's "checked" or not
+        value: true # whether it's "checked" or not
       },
       image: { image: @image, radius: 15 },
       remote_image: {  # remote image, requires JMImageCache CocoaPod
-        url: "http://placekitten.com/200/300", placeholder: "some-local-image",
-        size: 50, radius: 15
+        url: "http://placekitten.com/200/300",
+        placeholder: "some-local-image",
+        size: 50,
+        radius: 15
       },
-      subviews: [ @some_view, @some_other_view ] # arbitrary views added to the cell
+      style: {
+        masks_to_bounds: true,
+        background_color: UIColor.colorWithPatternImage(@image)
+      }
     })
   end
 
@@ -40,7 +43,7 @@ describe "PM::Table module" do
       },{
         title: "Table cell group 2", cells: [ cell_factory ]
       },{
-        title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory(title: "3-2", background_color: UIColor.blueColor) ]
+        title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory({title: "3-2", style: { background_color: UIColor.blueColor } }) ]
       },{
         title: "Table cell group 4", cells: [ custom_cell, cell_factory(title: "4-2"), cell_factory(title: "4-3"), cell_factory(title: "4-4") ]
       },{

--- a/spec/unit/tables/table_view_cell_spec.rb
+++ b/spec/unit/tables/table_view_cell_spec.rb
@@ -10,12 +10,21 @@ describe "PM::TableViewCellModule" do
       cell_style: UITableViewCellStyleSubtitle,
       cell_identifier: "Custom Cell",
       cell_class: PM::TableViewCell,
-      layer: { masks_to_bounds: true },
-      background_color: UIColor.redColor,
-      selection_style: UITableViewCellSelectionStyleGray,
-      accessory:{view: :switch, value: true}, # currently only :switch is supported
-      image: { image: UIImage.imageNamed("list"), radius: 15 },
-      subviews: [ UIView.alloc.initWithFrame(CGRectZero), UILabel.alloc.initWithFrame(CGRectZero) ] # arbitrary views added to the cell
+      accessory: {
+        view: :switch, # currently only :switch is supported
+        value: true
+      }, 
+      image: {
+        image: UIImage.imageNamed("list"),
+        radius: 15
+      },
+      selection_style: :gray,
+      style: {
+        layer: {
+          masks_to_bounds: true
+        },
+        background_color: UIColor.redColor
+      }
     }
   end
 
@@ -38,7 +47,7 @@ describe "PM::TableViewCellModule" do
         {
           title: "",
           cells: [
-            { title: "Test 1", accessory_type: UITableViewCellStateShowingEditControlMask },
+            { title: "Test 1", style: { accessory_type: UITableViewCellStateShowingEditControlMask } },
             custom_cell,
             { title: "Test2", accessory: { view: button } },
             attributed_cell
@@ -126,15 +135,6 @@ describe "PM::TableViewCellModule" do
     @subject.imageView.image.should == UIImage.imageNamed("list")
     @subject.imageView.layer.cornerRadius.should == 15.0
   end
-
-  it "should create two extra subviews" do
-    content_view = TestHelper.ios7 ? @subject.subviews.first : @subject
-    content_view.subviews.length.should == 3
-    content_view.subviews[1].class.should == UIView
-    content_view.subviews[2].class.should == UILabel
-  end
-
-
 
 end
 

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -34,7 +34,7 @@ describe "web screen properties" do
       end
     end
 
-    it "should called on_request hook" do
+    it "should call on_request hook" do
       @webscreen.open_url(NSURL.URLWithString('http://mixi.jp/'))
 
       wait_for_change @webscreen, 'on_request' do
@@ -46,42 +46,7 @@ describe "web screen properties" do
 
   end
 
-  describe "when use on_request hook by web brigde rpc" do
-    before do
-      class TestWebScreenWithRPC < TestWebScreen
-        attr_accessor :on_request, :on_request_args
-
-        def on_request(request, type)
-          self.on_request_args = [request, type]
-          self.on_request = true
-          # return false to prevent loadRequest
-          false
-        end
-      end
-      stub_request(:get, "http://mixi.jp/").
-        to_return(body: "<html><body>[mixi]</body></html>", content_type: "text/html")
-      # Simulate AppDelegate setup of web screen
-      @webscreen = TestWebScreenWithRPC.new modal: true, nav_bar: true, external_links: false
-    end
-
-    it "should called on_request hook" do
-      # simulate web bridge request from html links
-      @webscreen.open_url(NSURL.URLWithString('webbridge://method'))
-
-      wait_for_change @webscreen, 'on_request' do
-        request = @webscreen.on_request_args[0]
-        # on_request is called when @webscreen request for some iframe
-        request.URL.absoluteString.should == 'webbridge://method'
-      end
-
-      wait 0.3 do
-        # it should not load request when return false in on_request
-        !!(@webscreen.is_load_finished.should) == false
-      end
-    end
-  end
-
-  describe "when load static html file" do
+  describe "when loading a static html file" do
     before do
       # Simulate AppDelegate setup of web screen
       @webscreen = TestWebScreen.new modal: true, nav_bar: true, external_links: false


### PR DESCRIPTION
- Slimmed down TableViewCellModule by 30%
- Re-enabled some long-disabled tests (they passed)
- Added the `style:` attribute for cells — they no longer take arbitrary attributes in the main hash, but will `set_attributes` with whatever is in `style:`
- Removed a failing and head-scratching web bridge RPC spec (no idea what it was for)
