### PR TITLE
Allow delegate.open to animate open (usefull for closing splash pages)

### DIFF
--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -58,18 +58,20 @@ module ProMotion
       (defined?(Motion) && defined?(Motion::Xray) && defined?(Motion::Xray::XrayWindow)) ? Motion::Xray::XrayWindow : UIWindow
     end
 
-    def open_screen(screen, args={})
-
+    def open_screen(screen, args = {})
       screen = screen.new if screen.respond_to?(:new)
-
-      self.home_screen = screen
-
       self.window ||= self.ui_window.alloc.initWithFrame(UIScreen.mainScreen.bounds)
-      self.window.rootViewController = (screen.navigationController || screen)
+
+
+      if home_screen && args[:animated]
+        home_screen.navigationController.setViewControllers([screen], animated: true)
+      else
+        self.window.rootViewController = (screen.navigationController || screen)
+      end
+
       self.window.tintColor = self.class.send(:get_tint_color) if self.window.respond_to?("tintColor=")
       self.window.makeKeyAndVisible
-
-      screen
+      self.home_screen = screen
     end
     alias :open :open_screen
     alias :open_root_screen :open_screen

--- a/lib/ProMotion/screen/screen_navigation.rb
+++ b/lib/ProMotion/screen/screen_navigation.rb
@@ -15,7 +15,7 @@ module ProMotion
         self.split_screen.master_screen = screen
 
       elsif args[:close_all]
-        open_root_screen screen
+        open_root_screen screen, args
 
       elsif args[:modal]
         present_modal_view_controller screen, args[:animated], args[:completion]
@@ -35,8 +35,8 @@ module ProMotion
     end
     alias :open :open_screen
 
-    def open_root_screen(screen)
-      app_delegate.open_root_screen(screen)
+    def open_root_screen(screen, args = {})
+      app_delegate.open_root_screen(screen, args)
     end
 
     def open_modal(screen, args = {})

--- a/spec/unit/screen_helpers_spec.rb
+++ b/spec/unit/screen_helpers_spec.rb
@@ -152,7 +152,7 @@ describe "screen helpers" do
       # end
 
       it "should open a root screen if :close_all is provided" do
-        @screen.mock!(:open_root_screen) { |screen| screen.should.be.instance_of BasicScreen }
+        @screen.mock!(:open_root_screen) { |screen, args| screen.should.be.instance_of BasicScreen }
         screen = @screen.open BasicScreen, close_all: true
         screen.should.be.kind_of BasicScreen
       end


### PR DESCRIPTION
Occasionally, developers might wish for their splash pages to close and open a new home screen. This pull request allows allows for this screen opening to animate like a normal opening.
