### PR TITLE
WebScreen data detector fix and new feature

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -1,11 +1,12 @@
 module ProMotion
   module WebScreenModule
 
-    attr_accessor :webview, :external_links, :detector_types
+    attr_accessor :webview, :external_links, :detector_types, :scale_to_fit
 
     def screen_setup
       check_content_data
       self.external_links ||= false
+      self.scale_to_fit ||= false
       self.detector_types ||= :none
     end
 
@@ -24,6 +25,7 @@ module ProMotion
         delegate: self,
         data_detector_types: self.detector_types
       }
+      self.webview.scalesPageToFit = self.scale_to_fit
       self.webview.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
       set_initial_content
     end

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -72,6 +72,7 @@ describe "web screen properties" do
     it "should have a default values" do
       webscreen = TestWebScreen.new()
       webscreen.web.dataDetectorTypes.should == UIDataDetectorTypeNone
+      webscreen.web.scalesPageToFit.should == false
       webscreen.external_links.should == false
     end
 
@@ -83,6 +84,11 @@ describe "web screen properties" do
     it "should set multiple data detectors" do
       webscreen = TestWebScreen.new(detector_types: [:phone, :link])
       webscreen.web.dataDetectorTypes.should == UIDataDetectorTypePhoneNumber | UIDataDetectorTypeLink
+    end
+
+    it "should set the scaling mode of the screen" do
+      webscreen = TestWebScreen.new(scale_to_fit: true)
+      webscreen.web.scalesPageToFit.should == true
     end
 
     it "should have the ability to open links externally" do


### PR DESCRIPTION
There was a big when setting a single `data_detector` on `PM::WebScreen`. I fixed it and write a bunch of tests for attribute setting.

I also added an attribute so that the user can choose to set the `UIWebView.scalesPagesToFit` attribute more easily.
