### PR TITLE
Fixed issue #479 where a crash would occur on swipe left

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -225,13 +225,12 @@ module ProMotion
         none:   UITableViewCellEditingStyleNone,
         delete: UITableViewCellEditingStyleDelete,
         insert: UITableViewCellEditingStyleInsert
-      }[symbol] || symbol
+      }[symbol] || symbol || UITableViewCellEditingStyleNone
     end
 
     def map_row_animation_symbol(symbol)
       symbol ||= UITableViewRowAnimationAutomatic
       {
-        automatic:  UITableViewRowAnimationAutomatic,
         fade:       UITableViewRowAnimationFade,
         right:      UITableViewRowAnimationRight,
         left:       UITableViewRowAnimationLeft,
@@ -240,7 +239,7 @@ module ProMotion
         none:       UITableViewRowAnimationNone,
         middle:     UITableViewRowAnimationMiddle,
         automatic:  UITableViewRowAnimationAutomatic
-      }[symbol] || symbol
+      }[symbol] || symbol || UITableViewRowAnimationAutomatic
     end
 
     module TableClassMethods

--- a/spec/functional/func_table_screen_spec.rb
+++ b/spec/functional/func_table_screen_spec.rb
@@ -1,25 +1,32 @@
 describe "ProMotion::TestTableScreen functionality" do
   tests PM::TestTableScreen
 
-  # Override controller to properly instantiate
+  def table_screen
+    @table_screen ||= begin
+      t = TestTableScreen.new(nav_bar: true)
+      t.on_load
+      t
+    end
+  end
+
   def controller
     rotate_device to: :portrait, button: :bottom
-    @controller ||= TestTableScreen.new(nav_bar: true)
-    @controller.on_load
-    @controller.navigationController
+    table_screen.navigationController
   end
 
   def confirmation_class
     TestHelper.ios7 ? UITableViewCellDeleteConfirmationButton : UITableViewCellDeleteConfirmationControl
   end
 
+  after { @table_screen = nil }
+
   it "should have a navigation bar" do
-    @controller.navigationController.should.be.kind_of(UINavigationController)
+    table_screen.navigationController.should.be.kind_of(UINavigationController)
   end
 
   it "should increment the tap counter on tap" do
     tap("Increment")
-    @controller.tap_counter.should == 3
+    table_screen.tap_counter.should == 3
   end
 
   it "should add a new table cell on tap" do
@@ -29,34 +36,34 @@ describe "ProMotion::TestTableScreen functionality" do
 
   it "should do nothing when no action specified" do
     tap("Just another blank row")
-    @controller.should == @controller
+    table_screen.should == table_screen
   end
 
   it "should increment the tap counter by one on tap" do
     tap("Increment One")
-    @controller.tap_counter.should == 1
+    table_screen.tap_counter.should == 1
   end
 
   it "should delete the specified row from the table view on tap" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
+    table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 7
     tap("Delete the row below")
     wait 0.3 do
-      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
+      table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 6
     end
   end
 
   it "should delete the specified row from the table view on tap with an animation" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
+    table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 7
     tap("Delete the row below with an animation")
     wait 0.3 do
-      @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
+      table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 6
     end
   end
 
   # TODO: Why is it so complicated to find the delete button??
   it "should use editing_style to delete the table row" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
-    @controller.cell_was_deleted.should != true
+    table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 7
+    table_screen.cell_was_deleted.should != true
     flick("Just another deletable blank row", :to => :left)
 
     wait 0.25 do
@@ -65,8 +72,8 @@ describe "ProMotion::TestTableScreen functionality" do
         if subview.class == confirmation_class
           tap subview
           wait 0.25 do
-            @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 6
-            @controller.cell_was_deleted.should == true
+            table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 6
+            table_screen.cell_was_deleted.should == true
           end
         end
       end
@@ -74,8 +81,8 @@ describe "ProMotion::TestTableScreen functionality" do
   end
 
   it "should not allow deleting if on_cell_delete returns `false`" do
-    @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
-    @controller.cell_was_deleted.should != true
+    table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 7
+    table_screen.cell_was_deleted.should != true
     flick("A non-deletable blank row", :to => :left)
 
     wait 0.25 do
@@ -84,8 +91,8 @@ describe "ProMotion::TestTableScreen functionality" do
         if subview.class == confirmation_class
           tap subview
           wait 0.25 do
-            @controller.tableView(@controller.tableView, numberOfRowsInSection:0).should == 7
-            @controller.cell_was_deleted.should != false
+            table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 7
+            table_screen.cell_was_deleted.should != false
           end
         end
       end
@@ -93,32 +100,40 @@ describe "ProMotion::TestTableScreen functionality" do
   end
 
   it "should call a method when the switch is flipped" do
-    @controller.scroll_to_bottom
+    table_screen.scroll_to_bottom
     tap "switch_1"
     wait 0.3 do
-      @controller.tap_counter.should == 1
+      table_screen.tap_counter.should == 1
     end
   end
 
   it "should call the method with arguments when the switch is flipped and when the cell is tapped" do
-    @controller.scroll_to_bottom
+    table_screen.scroll_to_bottom
     tap "switch_3"
     wait 0.3 do
-      @controller.tap_counter.should == 3
+      table_screen.tap_counter.should == 3
 
       tap "Switch With Cell Tap, Switch Action And Parameters"
       wait 0.3 do
-        @controller.tap_counter.should == 13
+        table_screen.tap_counter.should == 13
       end
     end
   end
 
   it "should call the method with arguments when the switch is flipped" do
-    @controller.scroll_to_bottom
+    table_screen.scroll_to_bottom
     tap "switch_2"
     wait 0.3 do
-      @controller.tap_counter.should == 3
+      table_screen.tap_counter.should == 3
     end
+  end
+
+  it "should not crash if cell with editing_style is swiped left" do
+    Proc.new { flick("Just another deletable blank row", to: :left) }.should.not.raise(StandardError)
+  end
+
+  it "should not crash if cell with no editing_style is swiped left" do
+    Proc.new { flick("Increment", to: :left) }.should.not.raise(StandardError)
   end
 
 end

--- a/spec/helpers/test_helper.rb
+++ b/spec/helpers/test_helper.rb
@@ -3,3 +3,30 @@ class TestHelper
     UIDevice.currentDevice.systemVersion.to_f >= 7.0
   end
 end
+
+def silence_warnings(&block)
+  warn_level = $VERBOSE
+  $VERBOSE = nil
+  begin
+    result = block.call
+  ensure
+    $VERBOSE = warn_level
+  end
+  result
+end
+
+silence_warnings do
+  module Bacon
+    if ENV['filter']
+      $stderr.puts "Filtering specs that match: #{ENV['filter']}"
+      RestrictName = Regexp.new(ENV['filter'])
+    end
+
+    if ENV['filter_context']
+      $stderr.puts "Filtering contexts that match: #{ENV['filter_context']}"
+      RestrictContext = Regexp.new(ENV['filter_context'])
+    end
+
+    Backtraces = false if ENV['hide_backtraces']
+  end
+end


### PR DESCRIPTION
Also added a better spec runner from [this article](http://chen.do/blog/2013/06/03/running-individual-specs-with-rubymotion/) where you can do:

``` sh-session
$ rake spec filter="partial or full name of spec"                   # To filter by spec name
$ rake spec files=foo_spec filter="partial or full name of spec"
$ rake spec hide_backtraces=yes                     # Hide backtraces
```

Ref #479.

``` sh-session
240 specifications (463 requirements), 0 failures, 0 errors
```
