### PR TITLE
Fixed deprecation warning 'you should set :style in a style: hash'

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -23,7 +23,7 @@ module ProMotion
 
     # TODO: Remove this in ProMotion 2.1. Just for migration purposes.
     def check_deprecated_styles
-      whitelist = [ :title, :subtitle, :image, :remote_image, :accessory, :selection_style, :action, :long_press_action, :arguments, :cell_style, :cell_class, :cell_identifier, :editing_style, :search_text, :keep_selection, :height, :accessory_type ]
+      whitelist = [ :title, :subtitle, :image, :remote_image, :accessory, :selection_style, :action, :long_press_action, :arguments, :cell_style, :cell_class, :cell_identifier, :editing_style, :search_text, :keep_selection, :height, :accessory_type, :style ]
       if (data_cell.keys - whitelist).length > 0
         PM.logger.deprecated("In #{self.table_screen.class.to_s}#table_data, you should set :#{(data_cell.keys - whitelist).join(", :")} in a `style:` hash. See TableScreen documentation.")
       end


### PR DESCRIPTION
Hey guys, I received the error "you should set :style in a `style:` hash".
I guess this will fix that issue?!
