### PR TITLE
Add in tests for instance based navigation controller functionality

### DIFF
--- a/app/test_screens/navigation_controller.rb
+++ b/app/test_screens/navigation_controller.rb
@@ -1,0 +1,3 @@
+class CustomNavigationController < PM::NavigationController
+  
+end

--- a/lib/ProMotion/screen/nav_bar_module.rb
+++ b/lib/ProMotion/screen/nav_bar_module.rb
@@ -44,7 +44,7 @@ module ProMotion
     def add_nav_bar(args = {})
       self.navigationController ||= begin
         self.first_screen = true if self.respond_to?(:first_screen=)
-        nav = NavigationController.alloc.initWithRootViewController(self)
+        nav = (args[:nav_controller] || NavigationController).alloc.initWithRootViewController(self)
         nav.setModalTransitionStyle(args[:transition_style]) if args[:transition_style]
         nav.setModalPresentationStyle(args[:presentation_style]) if args[:presentation_style]
         nav

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -125,12 +125,18 @@ describe "screen properties" do
 
   describe "navigation controller behavior" do
 
-    it "should have a nav bar" do
-      @screen.nav_bar?.should == true
+    it "should let the instance set the nav_controller" do
+      screen = HomeScreen.new nav_bar: true, nav_controller: CustomNavigationController
+      screen.on_load
+      screen.navigationController.should.be.instance_of CustomNavigationController
     end
 
     it "#navigationController should return a navigation controller" do
       @screen.navigationController.should.be.instance_of ProMotion::NavigationController
+    end
+
+    it "should have a nav bar" do
+      @screen.nav_bar?.should == true
     end
 
     it "have a right bar button item" do
@@ -260,4 +266,5 @@ describe "screen with toolbar" do
     screen.set_toolbar_button([{title: "Testing Toolbar"}], false)
     screen.navigationController.toolbarHidden?.should == false
   end
+
 end


### PR DESCRIPTION
You can now pass `nav_controller: MyNavigationController` to PM::Screen.new.

``` ruby
class MyNavigationController < PM::NavigationController; end

screen = PM::Screen.new nav_bar: true, nav_controller: MyNavigationController
```

I also reordered a navigation controller spec in screen spec for a bit more intuitive coverage of screen instantiation with navigation controllers. 

Let me know how this looks and then I can go about updating the README/wiki per project standards.
