### PR TITLE
Fix invalid index_path crashes

### DIFF
--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -27,7 +27,9 @@ module ProMotion
       end
 
       table_section = self.section(params[:section])
+      return nil unless table_section
       c = table_section[:cells].at(params[:index].to_i)
+      return nil unless c
       set_data_cell_defaults c
     end
 

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -101,6 +101,7 @@ module ProMotion
     def table_view_cell(params={})
       params = index_path_to_section_index(params)
       data_cell = self.promotion_table_data.cell(section: params[:section], index: params[:index])
+      return nil if data_cell.nil?
       return UITableViewCell.alloc.init unless data_cell
       create_table_cell(data_cell)
     end

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -50,6 +50,11 @@ describe "table screens" do
       end
     end
 
+    it "should return nil when the index given is not found" do
+      index_path = NSIndexPath.indexPathForRow(7, inSection:0)
+      @screen.tableView(@screen.tableView, cellForRowAtIndexPath: index_path).should.be.nil
+    end
+
   end
 
   describe "search functionality" do


### PR DESCRIPTION
Fix issue where table_cell_data should return nil when an invalid index_path is given
