### PR TITLE
Support tint_color on toolbar buttons

### DIFF
--- a/lib/ProMotion/screen/nav_bar_module.rb
+++ b/lib/ProMotion/screen/nav_bar_module.rb
@@ -70,15 +70,21 @@ module ProMotion
     end
 
     def bar_button_item_image(img, args)
-      UIBarButtonItem.alloc.initWithImage(img, style: map_bar_button_item_style(args[:style]), target: args[:target] || self, action: args[:action])
+      button = UIBarButtonItem.alloc.initWithImage(img, style: map_bar_button_item_style(args[:style]), target: args[:target] || self, action: args[:action])
+      button.setTintColor args[:tint_color] if args[:tint_color]
+      button
     end
 
     def bar_button_item_string(str, args)
-      UIBarButtonItem.alloc.initWithTitle(str, style: map_bar_button_item_style(args[:style]), target: args[:target] || self, action: args[:action])
+      button = UIBarButtonItem.alloc.initWithTitle(str, style: map_bar_button_item_style(args[:style]), target: args[:target] || self, action: args[:action])
+      button.setTintColor args[:tint_color] if args[:tint_color]
+      button
     end
 
     def bar_button_item_system_item(args)
-      UIBarButtonItem.alloc.initWithBarButtonSystemItem(map_bar_button_system_item(args[:system_item]), target: args[:target] || self, action: args[:action])
+      button = UIBarButtonItem.alloc.initWithBarButtonSystemItem(map_bar_button_system_item(args[:system_item]), target: args[:target] || self, action: args[:action])
+      button.setTintColor args[:tint_color] if args[:tint_color]
+      button
     end
 
     def bar_button_item_custom(custom_view)

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -268,3 +268,26 @@ describe "screen with toolbar" do
   end
 
 end
+
+describe 'toolbar tinted buttons' do
+  before do
+    @screen = HomeScreen.new modal: true, nav_bar: true, toolbar: true
+    @screen.on_load
+  end
+
+  it "creates string toolbar buttons with tint colors" do
+    @screen.set_toolbar_button([{title: "Testing Toolbar", tint_color: UIColor.redColor}])
+    @screen.navigationController.toolbar.items.first.tintColor.should == UIColor.redColor
+  end
+
+  it "creates image toolbar buttons with tint colors" do
+    @screen.set_toolbar_button([{image: UIImage.imageNamed("list"), tint_color: UIColor.redColor}])
+    @screen.navigationController.toolbar.items.first.tintColor.should == UIColor.redColor
+  end
+
+  it "creates system item toolbar buttons with tint colors" do
+    @screen.set_toolbar_button([{system_item: :reply, tint_color: UIColor.redColor}])
+    @screen.navigationController.toolbar.items.first.tintColor.should == UIColor.redColor
+  end
+
+end


### PR DESCRIPTION
Complete with passing specs! <3

example usage:

``` ruby
    set_toolbar_items [{
      system_item: :flexible_space
    },{
      title: "Calculate Best Deal",
      action: :start_calculations,
      tint_color: UIColor.whiteColor
    },{
      system_item: :flexible_space
    }]
    self.navigationController.toolbar.barTintColor = rmq.color.purple
```

creates this:

![screen shot 2014-07-11 at 8 07 18 pm](https://cloud.githubusercontent.com/assets/139261/3560264/e71816d6-0960-11e4-8cf0-4bf408e8a376.png)
