### PR TITLE
Fix shouldAutorotate for VCs under the moreNavigationController

### DIFF
--- a/lib/ProMotion/cocoatouch/navigation_controller.rb
+++ b/lib/ProMotion/cocoatouch/navigation_controller.rb
@@ -1,11 +1,13 @@
 module ProMotion
   class NavigationController < UINavigationController
+
     def popViewControllerAnimated(animated)
       if self.viewControllers[-2].respond_to? :on_back
         self.viewControllers[-2].send(:on_back)
       end
       super animated
     end
+
     def shouldAutorotate
       visibleViewController.shouldAutorotate
     end
@@ -17,5 +19,6 @@ module ProMotion
     def preferredInterfaceOrientationForPresentation
       visibleViewController.preferredInterfaceOrientationForPresentation
     end
+
   end
 end

--- a/lib/ProMotion/cocoatouch/tab_bar_controller.rb
+++ b/lib/ProMotion/cocoatouch/tab_bar_controller.rb
@@ -40,15 +40,18 @@ module ProMotion
     # Cocoa touch methods below
 
     def shouldAutorotate
-      selectedViewController.shouldAutorotate if selectedViewController.respond_to?(:shouldAutorotate)
+      vc = selectedViewController.visibleViewController ? selectedViewController : moreNavigationController.visibleViewController
+      vc.shouldAutorotate if vc.respond_to?(:shouldAutorotate)
     end
 
     def supportedInterfaceOrientations
-      selectedViewController.supportedInterfaceOrientations if selectedViewController.respond_to?(:supportedInterfaceOrientations)
+      vc = selectedViewController.visibleViewController ? selectedViewController : moreNavigationController.visibleViewController
+      vc.supportedInterfaceOrientations if vc.respond_to?(:supportedInterfaceOrientations)
     end
 
     def preferredInterfaceOrientationForPresentation
-      selectedViewController.preferredInterfaceOrientationForPresentation if selectedViewController.respond_to?(:preferredInterfaceOrientationForPresentation)
+      vc = selectedViewController.visibleViewController ? selectedViewController : moreNavigationController.visibleViewController
+      vc.preferredInterfaceOrientationForPresentation if vc.respond_to?(:preferredInterfaceOrientationForPresentation)
     end
 
   end


### PR DESCRIPTION
Just about fixes #533. I'm still trying to figure out how somebody would disable rotation of the `UIMoreListController` but this at least fixes the crashes.
