### PR TITLE
Rename :style to :properties in cell hash (style will continue to work for a while)

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -23,14 +23,15 @@ module ProMotion
 
     # TODO: Remove this in ProMotion 2.1. Just for migration purposes.
     def check_deprecated_styles
-      whitelist = [ :title, :subtitle, :image, :remote_image, :accessory, :selection_style, :action, :long_press_action, :arguments, :cell_style, :cell_class, :cell_identifier, :editing_style, :search_text, :keep_selection, :height, :accessory_type, :style ]
+      whitelist = [ :title, :subtitle, :image, :remote_image, :accessory, :selection_style, :action, :long_press_action, :arguments, :cell_style, :cell_class, :cell_identifier, :editing_style, :search_text, :keep_selection, :height, :accessory_type, :style, :properties ]
       if (data_cell.keys - whitelist).length > 0
-        PM.logger.deprecated("In #{self.table_screen.class.to_s}#table_data, you should set :#{(data_cell.keys - whitelist).join(", :")} in a `style:` hash. See TableScreen documentation.")
+        PM.logger.deprecated("In #{self.table_screen.class.to_s}#table_data, you should set :#{(data_cell.keys - whitelist).join(", :")} in a `properties:` hash. See TableScreen documentation.")
       end
     end
 
     def set_styles
-      set_attributes self, data_cell[:style] if data_cell[:style]
+      data_cell[:properties] ||= data_cell[:style] || data_cell[:styles]
+      set_attributes self, data_cell[:properties] if data_cell[:properties]
     end
 
     def set_title

--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -67,6 +67,7 @@ module ProMotion
       end
       data_cell[:cell_class] ||= PM::TableViewCell
       data_cell[:cell_identifier] ||= build_cell_identifier(data_cell)
+      data_cell[:properties] ||= data_cell[:style] || data_cell[:styles]
 
       data_cell[:accessory] = {
         view: data_cell[:accessory],

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -166,7 +166,7 @@ module ProMotion
 
     def tableView(table_view, willDisplayCell: table_cell, forRowAtIndexPath: index_path)
       data_cell = self.promotion_table_data.cell(index_path: index_path)
-      set_attributes table_cell, data_cell[:style] if data_cell[:style]
+      set_attributes table_cell, data_cell[:properties] if data_cell[:properties]
       table_cell.send(:will_display) if table_cell.respond_to?(:will_display)
       table_cell.send(:restyle!) if table_cell.respond_to?(:restyle!) # Teacup compatibility
     end

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -29,7 +29,7 @@ describe "PM::Table module" do
         size: 50,
         radius: 15
       },
-      style: {
+      properties: {
         masks_to_bounds: true,
         background_color: UIColor.colorWithPatternImage(@image)
       }
@@ -44,7 +44,7 @@ describe "PM::Table module" do
       },{
         title: "Table cell group 2", cells: [ cell_factory ]
       },{
-        title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory({title: "3-2", style: { background_color: UIColor.blueColor } }) ]
+        title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory({title: "3-2", properties: { background_color: UIColor.blueColor } }) ]
       },{
         title: "Table cell group 4", cells: [ custom_cell, cell_factory(title: "4-2"), cell_factory(title: "4-3"), cell_factory(title: "4-4") ]
       },{

--- a/spec/unit/tables/table_view_cell_spec.rb
+++ b/spec/unit/tables/table_view_cell_spec.rb
@@ -19,7 +19,7 @@ describe "PM::TableViewCellModule" do
         radius: 15
       },
       selection_style: :gray,
-      style: {
+      properties: {
         layer: {
           masks_to_bounds: true
         },
@@ -48,7 +48,7 @@ describe "PM::TableViewCellModule" do
         {
           title: "",
           cells: [
-            { title: "Test 1", style: { accessory_type: UITableViewCellStateShowingEditControlMask } },
+            { title: "Test 1", properties: { accessory_type: UITableViewCellStateShowingEditControlMask } },
             custom_cell,
             { title: "Test2", accessory: { view: button } },
             attributed_cell


### PR DESCRIPTION
I've been unhappy with my poor name choice for this for a while, so this is to fix that. `style` will continue to work for several versions (probably version 3 or 4) but we will document with `properties`.

Feedback welcome.

``` ruby
def table_data
  [{
    cells: [{
      title: "My title",
      properties: { # Used to be `style:`
        any_writable_property: "My value"
      }
    }]
  }]
end
```

CC: issue #526.
