### PR TITLE
Added error message when user tries to run tests without having the appropriate RubyMotion version available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion
     - mkdir -p ~/Library/RubyMotion/build
-    - sudo motion update --cache-version=2.32
+    - sudo motion update --cache-version=2.33
 gemfile:
   - Gemfile
 script:

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-unless File.exist?("/Library/RubyMotion2.32/lib")
-  abort "Couldn't find RubyMotion 2.32. Run `sudo motion update --cache-version=2.32`."
+unless File.exist?("/Library/RubyMotion2.33/lib")
+  abort "Couldn't find RubyMotion 2.33. Run `sudo motion update --cache-version=2.33`."
 end
-$:.unshift("/Library/RubyMotion2.32/lib")
+$:.unshift("/Library/RubyMotion2.33/lib")
 require 'motion/project/template/ios'
 require 'bundler'
 Bundler.require(:development)


### PR DESCRIPTION
I ran into an issue where I couldn't run the specs in a newly cloned repo because I didn't have the correct RubyMotion version.

``` shell
rake aborted!
LoadError: cannot load such file -- motion/project/template/ios
/Users/kvg/Code/app/ProMotion/Rakefile:3:in `<top (required)>'
(See full trace by running task with --trace)
```

This update shows the user a more helpful error message including a suggestion on how to fix the root cause.

``` shell
Couldn't find RubyMotion 2.33. Run `sudo motion update --cache-version=2.33`.
```
