### PR TITLE
remove multiple calls to content method

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -37,7 +37,7 @@ module ProMotion
     def set_initial_content
       return unless self.respond_to?(:content)
       current_content = content
-      content.is_a?(NSURL) ? open_url(current_content) : set_content(current_content)
+      current_content.is_a?(NSURL) ? open_url(current_content) : set_content(current_content)
     end
 
     def set_content(content)


### PR DESCRIPTION
I kept having this error when trying to run the tests:

```
LoadError: cannot load such file -- ProMotion
/Users/.../ios/motionapps/ProMotion/Rakefile:9:in `require'
/Users/.../ios/motionapps/ProMotion/Rakefile:9:in `<top (required)>'  
```

I don't know what caused it, but when I ran `bundle exec rake spec`, It worked fine.
