### PR TITLE
Fix bug where app would crash is Screen.new() was called with a non-hash argument

### DIFF
--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -9,6 +9,7 @@ module ProMotion
     attr_accessor :parent_screen, :first_screen, :modal, :split_screen
 
     def screen_init(args = {})
+      args = {} unless args.is_a?(Hash)
       check_ancestry
       resolve_title
       apply_properties(args)


### PR DESCRIPTION
This fixes an instance where a user assigns an action to a table view cell and passes the arguments but doesn't specify a proper arguments hash:

``` ruby
def table_data
[cells:[{
  title: open screen,
  action: :open_screen
}]]
end

def open_screen(args={})
  # args here is a UITableViewCell
  open MyScreen.new(args)
end
```
