### PR TITLE
Scroll the table to show the refresh control unless the user initiates the refresh manually.

### DIFF
--- a/lib/ProMotion/table/extensions/refreshable.rb
+++ b/lib/ProMotion/table/extensions/refreshable.rb
@@ -19,6 +19,9 @@ module ProMotion
         return unless @refresh_control
 
         @refresh_control.beginRefreshing
+
+        # Scrolls the table down to show the refresh control when invoked programatically
+        table_view.setContentOffset(CGPointMake(0, table_view.contentOffset.y-@refresh_control.frame.size.height), animated:true) if table_view.contentOffset.y > -65.0
       end
       alias :begin_refreshing :start_refreshing
 


### PR DESCRIPTION
Makes invoking `start_refreshing` programmatically will now automatically show the refresh control. If the user pulls to refresh, the `contentOffset` is `> 65` so nothing is done.

Tested with and without a nav controller and works well.
