### PR TITLE
Allow users to pass nil as a cell and the tablescreen will ignore it.

### DIFF
--- a/app/test_screens/test_table_screen.rb
+++ b/app/test_screens/test_table_screen.rb
@@ -16,6 +16,7 @@ class TestTableScreen < ProMotion::TableScreen
       cells: [
         { title: "Increment", action: :increment_counter_by, arguments: {number: 3} },
         { title: "Add New Row", action: :add_tableview_row },
+        nil,
         { title: "Delete the row below", action: :delete_cell, arguments: {section: 0, row:3} },
         { title: "Just another deletable blank row", editing_style: :delete },
         { title: "A non-deletable blank row", editing_style: :delete },

--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -5,7 +5,10 @@ module ProMotion
     attr_accessor :data, :filtered_data, :search_string, :original_search_string, :filtered, :table_view
 
     def initialize(data, table_view)
-      self.data = data
+      self.data = data.map do |section|
+        section[:cells].compact!
+        section
+      end
       self.table_view = WeakRef.new(table_view)
     end
 


### PR DESCRIPTION
``` ruby
def table_data
  [{
    cells: [
      {title: 'something'},
     nil,
     {title: 'something else'}
    ]
  }]
end
```

will create a tableview with 2 cells instead of throwing an error.

Useful for those of us that want conditional cells based on some other logic and can return nil as a cell.
