### PR TITLE
Fix parent_screen weak ref bug.

### DIFF
--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -7,7 +7,8 @@ module ProMotion
     include ProMotion::Tabs
     include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad || (UIDevice.currentDevice.systemVersion.to_i >= 8 )
 
-    attr_accessor :parent_screen, :first_screen, :modal, :split_screen
+    attr_reader :parent_screen
+    attr_accessor :first_screen, :modal, :split_screen
 
     def screen_init(args = {})
       @screen_options = args
@@ -154,7 +155,7 @@ module ProMotion
     def add_child_screen(screen)
       screen = screen.new if screen.respond_to?(:new)
       addChildViewController(screen)
-      screen.parent_screen = WeakRef.new(self)
+      screen.parent_screen = self
       screen.didMoveToParentViewController(self) # Required
       screen
     end

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -449,7 +449,9 @@ describe "child screen management" do
   end
 
   it "#add_child_screen" do
-    @screen.add_child_screen @child
+    autorelease_pool do
+      @screen.add_child_screen @child
+    end
     @screen.childViewControllers.should.include(@child)
     @screen.childViewControllers.length.should == 1
     @child.parent_screen.should == @screen


### PR DESCRIPTION
`Screen#add_child_screen` wraps parent with weak-ref **twice**.
First, in its method.
Second, in the child screen's setter method `parent_screen=`.

This cause a referencing problem, showing:
```
[ERROR: WeakRef::RefError - Invalid Reference - probably recycled]
```
This is because the first WeakRef is not *strong-ref*ed by anybody, only *weak-ref*ed by the second WeakRef.
So the first WeakRef will be swept soon resulting in the second WeakRef referencing a lost object.


Along with fixing this problem, I moved `:parent_screen` from `attr_accessor` to `attr_reader`.
Because the setter method `parent_screen=` is defined explicitly.