### PR TITLE
adding support for NSMutableURLRequest

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -34,7 +34,13 @@ module ProMotion
 
     def set_initial_content
       return unless self.respond_to?(:content) && self.content
-      self.content.is_a?(NSURL) ? open_url(self.content) : set_content(self.content)
+      if self.content.is_a?(NSURL) 
+        open_url(self.content) 
+      elsif self.content.is_a?(NSMutableURLRequest)
+        web.loadRequest self.content
+      else
+        set_content(self.content)
+      end
     end
 
     def set_content(content)

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -34,7 +34,7 @@ describe "web screen properties" do
     
     it "should open web page via NSMutableURLRequest" do
       nsurl = NSURL.URLWithString('http://mixi.jp/')
-      @webscreen.open_url(NSMutableURLRequest.requestWithURL(nsurl))
+      @webscreen.web.loadRequest NSMutableURLRequest.requestWithURL(nsurl)
 
       wait_for_change @webscreen, 'is_load_finished' do
         @webscreen.current_url.should == 'http://mixi.jp/'

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -31,6 +31,15 @@ describe "web screen properties" do
         @webscreen.current_url.should == 'http://mixi.jp/'
       end
     end
+    
+    it "should open web page via NSMutableURLRequest" do
+      nsurl = NSURL.URLWithString('http://mixi.jp/')
+      @webscreen.open_url(NSMutableURLRequest.requestWithURL(nsurl))
+
+      wait_for_change @webscreen, 'is_load_finished' do
+        @webscreen.current_url.should == 'http://mixi.jp/'
+      end
+    end
 
     it "should open web page by url string" do
       @webscreen.open_url('http://mixi.jp/')


### PR DESCRIPTION
As the subject line suggests, this pull request adds support for NSMutableURLRequest as the content in a PM::WebScreen.  This allows for the addition of headers to the request.