### PR TITLE
Implement section footer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 $:.unshift("/Library/RubyMotion/lib")
 require 'motion/project/template/ios'
 require 'bundler'
+Bundler.setup
 Bundler.require(:development)
 require 'ProMotion'
 require 'motion_print'

--- a/app/test_views/dynamic_height_footer_view.rb
+++ b/app/test_views/dynamic_height_footer_view.rb
@@ -1,0 +1,26 @@
+class DynamicHeightFooterView < UIView
+  def on_load
+    @height = 12.0
+  end
+
+  def title=(t)
+    # Do something here
+  end
+
+  def height
+    @height
+  end
+end
+
+
+class DynamicHeightFooterView40 < DynamicHeightFooterView
+  def on_load
+    @height = 40.0
+  end
+end
+
+class DynamicHeightFooterView121 < DynamicHeightFooterView
+  def on_load
+    @height = 121.0
+  end
+end

--- a/app/views/custom_footer_view.rb
+++ b/app/views/custom_footer_view.rb
@@ -1,0 +1,4 @@
+class CustomFooterView < UITableViewCell
+  attr_accessor :title
+end
+

--- a/docs/Reference/ProMotion Table - Cell Options.md
+++ b/docs/Reference/ProMotion Table - Cell Options.md
@@ -4,9 +4,12 @@ you really should be subclassing them and specifying that new class in <code>:ce
 ```ruby
 def table_data
   [{
-    title: "Group Title",
-    title_view: MyCustomSection,
+    title: "Group Header",
+    title_view: MyCustomSectionHeader,
     title_view_height: 50,
+    footer: "Group Footer",
+    footer_view: MyCustomSectionFooter,
+    footer_view_height: 50,
     cells: [{
       # Title
       title: "Full featured cell",

--- a/docs/Reference/ProMotion TableScreen table_data Options.md
+++ b/docs/Reference/ProMotion TableScreen table_data Options.md
@@ -5,15 +5,26 @@ you really should be subclassing them and specifying that new class in <code>:ce
 def table_data
   [{
     # Section title
-    title: "Group Title",
+    title: "Group Header",
     # Custom UIView suclass for a section header.
     # If your class responds to `title=`, it will be called automatically
     # with the content from the `title:` option above.
-    title_view: MyCustomSection,
+    title_view: MyCustomSectionHeader,
     # You can manually set the section title view height. If your class responds
     # to `height`, it will be called automatically and that will be the height.
     # If you specify it here, this number takes precedence.
     title_view_height: 50,
+
+    # Section footer
+    footer: "Group Footer",
+    # Custom UIView suclass for a section header.
+    # If your class responds to `title=`, it will be called automatically
+    # with the content from the `footer:` option above.
+    footer_view: MyCustomSectionFooter,
+    # You can manually set the section footer view height. If your class responds
+    # to `height`, it will be called automatically and that will be the height.
+    # If you specify it here, this number takes precedence.
+    footer_view_height: 50,
 
     cells: [
       # See cell options documentation
@@ -24,13 +35,13 @@ end
 
 ## Using :title_view
 
-You can specify your own section header title view and it will automatically be
+You can specify your own section header view and it will automatically be
 sized appropriately if your custom UIView subclass implements the `height` method.
 
 For example (using RMQ):
 
 ```ruby
-class TableSectionHeaderView < UIView
+class MyCustomSectionHeader < UIView
   # This will create table section header view with a UILabel
   # with the correct font (defined in application_stylesheet.rb)
   # for section headers.
@@ -39,7 +50,7 @@ class TableSectionHeaderView < UIView
   #
   # def table_data
   #   [{
-  #     title_view: TableSectionHeaderView,
+  #     title_view: MyCustomSectionHeader,
   #     title: "Whatever string you want"
   #   }]
   # end
@@ -50,6 +61,61 @@ class TableSectionHeaderView < UIView
 
     # Create the UILabel and set the data to the text provided
     @title = append(UILabel, :table_section_header_label)
+  end
+
+  def title=(t)
+    @title.data = t
+
+    # Resize the title frame to fit the text
+    @title.style{|st| st.resize_height_to_fit }
+
+    # Resize the view instance height
+    @v.style do |st|
+      st.frame = {
+        h: @title.frame.size.height + 15
+      }
+    end
+  end
+
+  # Return the height of the view
+  def height
+    self.frame.size.height
+  end
+end
+```
+
+## Using :footer_view
+
+You can specify your own section footer view and it will automatically be
+sized appropriately if your custom UIView subclass implements the `height` method.
+
+Note that inside the class, the content of the footer is called `title`. This
+is not to be confused with the `title` key that you can pass in the section hash
+to set the header content.
+
+For example (using RMQ):
+
+```ruby
+class MyCustomSectionFooter < UIView
+  # This will create table section footer view with a UILabel
+  # with the correct font (defined in application_stylesheet.rb)
+  # for section footers.
+  #
+  # Instructions on how to use:
+  #
+  # def table_data
+  #   [{
+  #     footer_view: MyCustomSectionFooter,
+  #     footer: "Whatever string you want"
+  #   }]
+  # end
+
+  def on_load
+    # Apply a style to the view instance
+    @v = find(self).apply_style(:table_section_footer_view)
+
+    # Create the UILabel and set the data to the text provided
+    @title = append(UILabel, :table_section_footer_label)
   end
 
   def title=(t)

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -187,6 +187,11 @@ module ProMotion
       section && section[:title]
     end
 
+    def tableView(_, titleForFooterInSection: section)
+      section = promotion_table_data.section(section)
+      section && section[:footer]
+    end
+
     # Set table_data_index if you want the right hand index column (jumplist)
     def sectionIndexTitlesForTableView(_)
       return if self.promotion_table_data.filtered
@@ -287,7 +292,7 @@ module ProMotion
       delete_row(index_paths, animation)
     end
 
-    # Section view methods
+    # Section header view methods
     def tableView(_, viewForHeaderInSection: index)
       section = promotion_table_data.section(index)
       view = section[:title_view]
@@ -314,6 +319,42 @@ module ProMotion
 
     def tableView(_, willDisplayHeaderView:view, forSection:section)
       action = :will_display_header
+      if respond_to?(action)
+        case self.method(action).arity
+        when 0 then self.send(action)
+        when 2 then self.send(action, view, section)
+        else self.send(action, view)
+        end
+      end
+    end
+
+    # Section footer view methods
+    def tableView(_, viewForFooterInSection: index)
+      section = promotion_table_data.section(index)
+      view = section[:footer_view]
+      view = section[:footer_view].new if section[:footer_view].respond_to?(:new)
+      view.on_load if view.respond_to?(:on_load)
+      view.title = section[:footer] if view.respond_to?(:title=)
+      view
+    end
+
+    def tableView(_, heightForFooterInSection: index)
+      section = promotion_table_data.section(index)
+      if section[:footer_view] || section[:footer].to_s.length > 0
+        if section[:footer_view_height]
+          section[:footer_view_height]
+        elsif (section_footer = tableView(_, viewForFooterInSection: index)) && section_footer.respond_to?(:height)
+          section_footer.height
+        else
+          tableView.sectionFooterHeight
+        end
+      else
+        0.0
+      end
+    end
+
+    def tableView(_, willDisplayFooterView:view, forSection:section)
+      action = :will_display_footer
       if respond_to?(action)
         case self.method(action).arity
         when 0 then self.send(action)

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -52,13 +52,13 @@ describe "PM::Table module" do
   end
 
   def default_cell_height
-    return UITableViewAutomaticDimension if TestHelper.ios8
+    return UITableViewAutomaticDimension if TestHelper.gte_ios8
     return 97.0 if TestHelper.ios7 # Normally 44, but 97 because of `row_height` designation
   end
 
   def default_header_height
     # Thanks, Apple.
-    return -1.0 if TestHelper.ios8
+    return -1.0 if TestHelper.gte_ios8
     return 23.0 if TestHelper.ios7
     return 22.0 if TestHelper.ios6
   end

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -63,29 +63,44 @@ describe "PM::Table module" do
     return 22.0 if TestHelper.ios6
   end
 
+  def default_footer_height
+    # Couldn't alias_method inside of a Bacon::Context so I'm defining this
+    # method to just call default_header_height. I'm reasonably sure that
+    # the defaults are the same for section headers and footers.
+    default_header_height
+  end
+
   before do
     @subject = TestTableScreen.new
     @subject.mock! :table_data do
       [{
-        title: "Table cell group 1", cells: [ ]
-      },{
-        title: "Table cell group 2", cells: [ cell_factory ]
-      },{
-        title: "Table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory({title: "3-2", properties: { background_color: UIColor.blueColor } }) ]
-      },{
-        title: "Table cell group 4", cells: [ custom_cell, cell_factory(title: "4-2"), cell_factory(title: "4-3"), cell_factory(title: "4-4") ]
-      },{
+        title: "Table cell group 1", :footer => "Footer for table cell group 1", cells: [ ]
+      }, {
+        title: "Table cell group 2", :footer => "Footer for table cell group 2", cells: [ cell_factory ]
+      }, {
+        title: "Table cell group 3", :footer => "Footer for table cell group 3", cells: [ cell_factory(title: "3-1"), cell_factory({title: "3-2", properties: { background_color: UIColor.blueColor } }) ]
+      }, {
+        title: "Table cell group 4", :footer => "Footer for table cell group 4", cells: [ custom_cell, cell_factory(title: "4-2"), cell_factory(title: "4-3"), cell_factory(title: "4-4") ]
+      }, {
         title: "Custom section title 1", title_view: CustomTitleView, cells: [ ]
-      },{
+      }, {
         title: "Custom section title 2", title_view: CustomTitleView.new, title_view_height: 50, cells: [ ]
-      },{
+      }, {
         title: "Action With Index Path Group", cells: [ cell_factory(title: "IndexPath Group 1", action: :tests_index_path) ]
       }, {
         title: "Action With A Proc", cells: [ proc_cell ]
-      },{
+      }, {
         title: "test 40", title_view: DynamicHeightTitleView40, cells: []
       }, {
         title: "test 121", title_view: DynamicHeightTitleView121, cells: []
+      }, {
+        footer: "Custom section footer 1", footer_view: CustomFooterView, cells: [ ]
+      }, {
+        footer: "Custom section footer 2", footer_view: CustomFooterView.new, footer_view_height: 50, cells: [ ]
+      }, {
+        footer: "Footer test 40", footer_view: DynamicHeightFooterView40, cells: []
+      }, {
+        footer: "Footer test 121", footer_view: DynamicHeightFooterView121, cells: []
       }]
     end
 
@@ -99,7 +114,7 @@ describe "PM::Table module" do
   end
 
   it "should have the right number of sections" do
-    @subject.numberOfSectionsInTableView(@subject.table_view).should == 10
+    @subject.numberOfSectionsInTableView(@subject.table_view).should == 14
   end
 
   it "should set the section titles" do
@@ -109,6 +124,15 @@ describe "PM::Table module" do
     @subject.tableView(@subject.table_view, titleForHeaderInSection:3).should == "Table cell group 4"
     @subject.tableView(@subject.table_view, titleForHeaderInSection:4).should == "Custom section title 1"
     @subject.tableView(@subject.table_view, titleForHeaderInSection:5).should == "Custom section title 2"
+  end
+
+  it "should set the section footers" do
+    @subject.tableView(@subject.table_view, titleForFooterInSection:0).should == "Footer for table cell group 1"
+    @subject.tableView(@subject.table_view, titleForFooterInSection:1).should == "Footer for table cell group 2"
+    @subject.tableView(@subject.table_view, titleForFooterInSection:2).should == "Footer for table cell group 3"
+    @subject.tableView(@subject.table_view, titleForFooterInSection:3).should == "Footer for table cell group 4"
+    @subject.tableView(@subject.table_view, titleForFooterInSection:10).should == "Custom section footer 1"
+    @subject.tableView(@subject.table_view, titleForFooterInSection:11).should == "Custom section footer 2"
   end
 
   it "should create the right number of cells" do
@@ -121,7 +145,7 @@ describe "PM::Table module" do
   end
 
   it "should create the jumplist" do
-    @subject.mock! :table_data_index, do
+    @subject.mock!(:table_data_index) do
       Array("A".."Z")
     end
 
@@ -223,6 +247,32 @@ describe "PM::Table module" do
     it "should set the height of a title view when the method `height` is implemented" do
       @subject.tableView(@subject.table_view, heightForHeaderInSection:8).should == 40.0
       @subject.tableView(@subject.table_view, heightForHeaderInSection:9).should == 121.0
+    end
+  end
+
+  describe("section with custom footer_view") do
+
+    it "should use the correct class for section view" do
+      cell = @subject.tableView(@subject.table_view, viewForFooterInSection: 10)
+      cell.should.be.kind_of(CustomFooterView)
+    end
+
+    it "should use the default section height if none is specified" do
+      @subject.tableView(@subject.table_view, heightForFooterInSection: 10).should == default_footer_height
+    end
+
+    it "should use the set footer_view_height if one is specified" do
+      @subject.tableView(@subject.table_view, heightForFooterInSection: 11).should == 50.0
+    end
+
+    it "should use the instantiated section view if one is specified" do
+      cell = @subject.tableView(@subject.table_view, viewForFooterInSection: 11)
+      cell.should.be.kind_of(CustomFooterView)
+    end
+
+    it "should set the height of a title view when the method `height` is implemented" do
+      @subject.tableView(@subject.table_view, heightForFooterInSection: 12).should == 40.0
+      @subject.tableView(@subject.table_view, heightForFooterInSection: 13).should == 121.0
     end
   end
 


### PR DESCRIPTION
This sets up section footer functionality that works in the same way as the section headers. The `footer`, `footer_view`, and `footer_view_height` work in the same way as their `title_*` analogs.

This also includes a small commit to update the specs to account for iOS9.

<img width="487" alt="screen shot 2015-11-19 at 4 31 09 pm" src="https://cloud.githubusercontent.com/assets/847027/11284978/03a1da16-8edb-11e5-90e5-259b58f8d69a.png">
