### PR TITLE
Allow handling tabBarController:shouldSelectViewController

### DIFF
--- a/app/screens/test_delegate.rb
+++ b/app/screens/test_delegate.rb
@@ -1,7 +1,10 @@
 class TestDelegate < ProMotion::Delegate
   status_bar false
 
-  attr_accessor :called_on_load, :called_will_load, :called_on_activate, :called_will_deactivate, :called_on_enter_background, :called_will_enter_foreground, :called_on_unload, :called_on_tab_selected
+  attr_accessor :called_on_load, :called_will_load, :called_on_activate,
+    :called_will_deactivate, :called_on_enter_background, :called_will_enter_foreground,
+    :called_on_unload, :called_should_select_tab, :called_on_tab_selected
+
   def on_load(app, options)
     self.called_on_load = true
   end
@@ -28,6 +31,12 @@ class TestDelegate < ProMotion::Delegate
 
   def on_unload
     self.called_on_unload = true
+  end
+
+  def should_select_tab(vc)
+    self.called_should_select_tab = true
+
+    true
   end
 
   def on_tab_selected(vc)

--- a/spec/unit/tab_bar_spec.rb
+++ b/spec/unit/tab_bar_spec.rb
@@ -24,10 +24,40 @@ describe "PM::Tabs" do
     tab_bar.delegate.should.equal(tab_bar)
   end
 
+  it "should call should_select_tab before a tab is selected" do
+    tab_bar.pm_tab_delegate.called_should_select_tab = false
+    @screen1.open_tab "Screen 2"
+    tab_bar.pm_tab_delegate.called_should_select_tab.should.be.true
+  end
+
   it "should call on_tab_selected when a tab is selected" do
     tab_bar.pm_tab_delegate.called_on_tab_selected = false
     @screen1.open_tab "Screen 2"
     tab_bar.pm_tab_delegate.called_on_tab_selected.should.be.true
+  end
+
+  it "should call on_tab_selected when delegate does not respond to should_select_tab" do
+    method_to_stub = :can_send_method_to_delegate?
+    tab_bar.pm_tab_delegate.stub!(method_to_stub) do |method|
+      method == :should_select_tab ? false : send("__original_#{method_to_stub}", method)
+    end
+
+    tab_bar.pm_tab_delegate.called_on_tab_selected = false
+    @screen1.open_tab "Screen 2"
+    tab_bar.pm_tab_delegate.called_on_tab_selected.should.be.true
+
+    tab_bar.pm_tab_delegate.reset(method_to_stub)
+  end
+
+  it "does not call on_tab_selected when should_select_tab returns false" do
+    method_to_stub = :should_select_tab
+    tab_bar.pm_tab_delegate.stub!(method_to_stub) { |_vc| false }
+
+    tab_bar.pm_tab_delegate.called_on_tab_selected = false
+    @screen1.open_tab "Screen 2"
+    tab_bar.pm_tab_delegate.called_on_tab_selected.should.be.false
+
+    tab_bar.pm_tab_delegate.reset(method_to_stub)
   end
 
   it "should have four tabs" do


### PR DESCRIPTION
When a tab is selected, iOS first calls the method `tabBarController:shouldSelectViewController` to determine whether or not it should actually select the tab. Returning false prevents the tab from being selected.

This commit enables the tab delegate to implement this functionality. The method is called on the cocoatouch event but also when `open_tab` is called programmatically to ensure consistent behavior. If the delegate does not implement a handler the method just returns true so this change is backwards compatible.