### PR TITLE
Live-reloading of motion-kit layouts

### DIFF
--- a/lib/ProMotion/repl/repl.rb
+++ b/lib/ProMotion/repl/repl.rb
@@ -17,13 +17,13 @@ if RUBYMOTION_ENV == "development"
         "Live reloading of PM screens is now off."
       else
         @watchers = live_reloaders.collect {|reloader| reloader.(opts)}
+        mp @watchers if opts[:debug]
 
-        mp @watchers
-
-        #TODO -- report the paths here
-        "Live reloading of screens, views, and layouts is now on."
+        watching = @watchers.collect {|watcher| watcher.path_query}
+        "Live reloading of #{watching.join(", ")} is now on."
       end
     end
+
     alias_method :pm_live_screens, :pm_live
 
 
@@ -64,12 +64,6 @@ if RUBYMOTION_ENV == "development"
     end
 
     register_live_reloader view_watcher
-
-    def pm_is_layout?(vc, layout_code)
-      definition = layout_code.detect {|e| e =~ /class\s*(\S*)Layout/}
-      screen_name = "#{$1}Screen"
-      vc.class.to_s == screen_name
-    end
 
     # Very permissive. Might get unnecessary reloads. That's okay.
     def pm_is_in_ancestry?(vc, screen_names)

--- a/lib/ProMotion/repl/repl.rb
+++ b/lib/ProMotion/repl/repl.rb
@@ -33,7 +33,7 @@ if RUBYMOTION_ENV == "development"
           vcs = pm_all_view_controllers(UIApplication.sharedApplication.delegate.window.rootViewController)
           vcs.each do |vc|
             if pm_is_layout?(vc, class_names) 
-              puts "Sending :on_live_reload to #{vc.inspect}." #if opts[:debug]
+              puts "Sending :on_live_reload to #{vc.inspect}." if opts[:debug]
               vc.send(:on_live_reload) if vc.respond_to?(:on_live_reload)
             end
           end


### PR DESCRIPTION
Referencing [this issue](https://github.com/motion-kit/motion-kit/issues/131) from the motion-kit gem.

This implementation is pretty basic; it simply watches the app/layouts folder and reloads the view controller that matches <LayoutName>Screen using class name.

1. To make this generic, would need to refactor Kernel in repl.rb to use a collection of LiveReloaders and provide a registration capability.  This PR could them become a separate gem that uses this capability. 

2. Also looking into parsing the code of each ViewController and looking for references to the Layout class; this removes the need for naming convention. 

Thoughts on the above items/any additional considerations?

