### PR TITLE
Call setNeedsLayout after remote image has been downloaded

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -67,6 +67,7 @@ module ProMotion
           progress:nil,
           completed: -> image, error, cacheType, finished {
             self.imageView.image = image unless image.nil?
+            self.setNeedsLayout
         })
       elsif jm_image_cache?
         mp "'JMImageCache' is known to have issues with ProMotion. Please consider switching to 'SDWebImage'. 'JMImageCache' support will be deprecated in the next major version.", force_color: :yellow


### PR DESCRIPTION
This PR adds a missing line of code. When setting a remote image, using SDWebImage, it's important to call `setNeedsLayout` after updating the image so that the imageView and label frames can be adjusted. Otherwise you will see some strange results, like images shifting when you click on them or resizing when they scroll into view.