### PR TITLE
Fix Travis build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion
     - mkdir -p ~/Library/RubyMotion/build
-    - sudo motion update
+    - sudo motion update || echo 'RubyMotion up to date'
 gemfile:
   - Gemfile
 script:


### PR DESCRIPTION
When RubyMotion is updated during the Travis build, the update command
returns an exit code of 1 if the software is already up to date.
According to the [Travis
documentation](https://docs.travis-ci.com/user/customizing-the-build/),
a non-zero exit code will cause the build to fail.

See https://travis-ci.org/infinitered/ProMotion/builds/145458532 for an
example of a failing build.

Catching this non-error lets us continue with the build.