### PR TITLE
Fix iOS10 crashing when image picker is called

### DIFF
--- a/lib/ProMotion/cocoatouch/navigation_controller.rb
+++ b/lib/ProMotion/cocoatouch/navigation_controller.rb
@@ -11,6 +11,7 @@ module ProMotion
     end
 
     def supportedInterfaceOrientations
+      return UIInterfaceOrientationMaskAll unless visibleViewController
       visibleViewController.supportedInterfaceOrientations
     end
 


### PR DESCRIPTION
When presenting a `UIImagePickerController` the app would crash because
`visibleViewController` was `nil` when being called by the navigation
controller.

The actual changes to iOS10 implementation of `visibleViewController`
remains a mystery, but this adds a sensible fallback in the case that
it's set to nil.

Fixes #795.