### PR TITLE
Add defensive property check to TableViewCellModule layoutSubviews

### DIFF
--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -21,6 +21,7 @@ module ProMotion
 
     def layoutSubviews
       super
+      return unless data_cell
 
       # Support changing sizes of the image view
       if (data_cell[:image] && data_cell[:image].is_a?(Hash) && data_cell[:image][:size])


### PR DESCRIPTION
In some cases, the `layoutSubviews` of `TableViewCellModule` gets called before its `data_cell` instance variable has been set. As a result, `layoutSubviews` will raise an exception when trying to access methods of `data_cell`.

This change checks that `data_cell` is truthy before proceeding.

(Using RubyMotion 4.22 with iOS 10.2 Simulator and iOS 10.3.3 on device.)