### PR TITLE
Support SDWebImage both v3 and v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion

--- a/ProMotion.gemspec
+++ b/ProMotion.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("motion_print", "~> 1.0")
   gem.add_development_dependency("webstub", "~> 1.1")
   gem.add_development_dependency("motion-stump", "~> 0.3")
-  gem.add_development_dependency("motion-redgreen", "~> 0.1")
+  gem.add_development_dependency("motion-redgreen", "~> 1.0")
   gem.add_development_dependency("rake")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Motion::Project::App.setup do |app|
   app.device_family = [ :ipad ] # so we can test split screen capability
   app.detect_dependencies = false
   app.info_plist["UIViewControllerBasedStatusBarAppearance"] = false
-  app.deployment_target = "7.1"
+  app.deployment_target = "8.0"
 
   # Adding file dependencies for tests
   # Not too many dependencies necessary

--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -63,13 +63,25 @@ module ProMotion
       self.imageView.image = remote_placeholder
 
       if sd_web_image?
-        @remote_image_operation = SDWebImageManager.sharedManager.loadImageWithURL(data_cell[:remote_image][:url].to_url,
-          options:SDWebImageRefreshCached | SDWebImageScaleDownLargeImages,
-          progress:nil,
-          completed: -> image, imageData, error, cacheType, finished, imageURL {
-            self.imageView.image = image unless image.nil?
-            self.setNeedsLayout
-        })
+        if SDWebImageManager.sharedManager.respond_to?('downloadWithURL:options:progress:completed:')
+          # SDWebImage 3.x
+          @remote_image_operation = SDWebImageManager.sharedManager.downloadWithURL(data_cell[:remote_image][:url].to_url,
+            options:SDWebImageRefreshCached,
+            progress:nil,
+            completed: -> image, error, cacheType, finished {
+              self.imageView.image = image unless image.nil?
+              self.setNeedsLayout
+          })
+        else
+          # SDWebImage 4.x
+          @remote_image_operation = SDWebImageManager.sharedManager.loadImageWithURL(data_cell[:remote_image][:url].to_url,
+            options:SDWebImageRefreshCached | SDWebImageScaleDownLargeImages,
+            progress:nil,
+            completed: -> image, imageData, error, cacheType, finished, imageURL {
+              self.imageView.image = image unless image.nil?
+              self.setNeedsLayout
+          })
+        end
       elsif jm_image_cache?
         mp "'JMImageCache' is known to have issues with ProMotion. Please consider switching to 'SDWebImage'. 'JMImageCache' support will be deprecated in the next major version.", force_color: :yellow
         JMImageCache.sharedCache.imageForURL(data_cell[:remote_image][:url].to_url, completionBlock:proc { |downloaded_image|

--- a/lib/ProMotion/table/cell/table_view_cell_module.rb
+++ b/lib/ProMotion/table/cell/table_view_cell_module.rb
@@ -63,10 +63,10 @@ module ProMotion
       self.imageView.image = remote_placeholder
 
       if sd_web_image?
-        @remote_image_operation = SDWebImageManager.sharedManager.downloadWithURL(data_cell[:remote_image][:url].to_url,
-          options:SDWebImageRefreshCached,
+        @remote_image_operation = SDWebImageManager.sharedManager.loadImageWithURL(data_cell[:remote_image][:url].to_url,
+          options:SDWebImageRefreshCached | SDWebImageScaleDownLargeImages,
           progress:nil,
-          completed: -> image, error, cacheType, finished {
+          completed: -> image, imageData, error, cacheType, finished, imageURL {
             self.imageView.image = image unless image.nil?
             self.setNeedsLayout
         })


### PR DESCRIPTION
* Update table cell remote_image according to SDWebImage API changes.
  See "[SDWebImage 4.0 Migration Guide](https://github.com/rs/SDWebImage/blob/master/Docs/SDWebImage-4.0-Migration-guide.md#using-directly-sdwebimagemanager)"
* Update travis.yml because travis-ci dropped xcode-7.2 support