### PR TITLE
Feature/bugfix: update status bar methods to work with newer versions of iOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios'
 require 'bundler'
 Bundler.setup
@@ -10,8 +11,6 @@ require 'motion_print'
 Motion::Project::App.setup do |app|
   app.name = 'ProMotion'
   app.device_family = [ :ipad ] # so we can test split screen capability
-  app.detect_dependencies = false
-  app.info_plist["UIViewControllerBasedStatusBarAppearance"] = false
   app.deployment_target = "8.0"
 
   # Adding file dependencies for tests

--- a/docs/Reference/ProMotion Delegate.md
+++ b/docs/Reference/ProMotion Delegate.md
@@ -12,7 +12,7 @@ The PM::Delegate gives you ProMotion's nice API for your AppDelegate class.
 ```ruby
 # app/app_delegate.rb
 class AppDelegate < PM::Delegate
-  status_bar false, animation: :none
+  status_bar :dark, animation: :none
 
   def on_load(app, options)
     open HomeScreen
@@ -25,7 +25,7 @@ If you need to inherit from a different AppDelegate superclass, do this:
 ```ruby
 class AppDelegate < JHMyParentDelegate
   include PM::DelegateModule
-  status_bar false, animation: :none
+  status_bar :dark, animation: :none
 
   def on_load(app, options)
     open HomeScreen
@@ -148,18 +148,36 @@ end
 
 #### status_bar
 
-Class method that allows hiding or showing the status bar. Setting this to `false` will hide it throughout the app.
+This class method allows you to configure the default setting of whether or not to show the status bar and whether you want the status bar text to appear light or dark. You may also optionally specify the animation style when hiding/showing the status bar. These will become the default setting throughout the app. Note that if you specify `:light` as the status bar style, and the current screen uses a navigation bar, the bar style must have a dark style in order for the status bar to have white text.
+
+**Style Options:**
+- `:dark` (default)
+- `:light`
+- `:hidden`/`:none`
+
+**Animation Options:**
+- `:fade` (default)
+- `:slide`
+- `:none`
 
 ```ruby
 class AppDelegate < PM::Delegate
-  status_bar true, animation: :none # :slide, :fade
+  status_bar :light, animation: :fade
 end
 ```
 
-If you want the status bar to be hidden on the splash screen you must set this in your rakefile.
+**Configuring status bar appearance during app launch**
+
+If you want the status bar to be initially hidden when the app launches, you must set this `info_plist` setting in your rakefile.
 
 ```ruby
 app.info_plist['UIStatusBarHidden'] = true
+```
+
+To configure the style (light or dark text) of the status bar during app launch, you can configure the `status_bar_style` project config setting in your rakefile.
+
+```ruby
+app.status_bar_style = :light_content # or :default (dark)
 ```
 
 #### tint_color

--- a/docs/Reference/ProMotion Screen.md
+++ b/docs/Reference/ProMotion Screen.md
@@ -611,18 +611,44 @@ end
 
 #### status_bar(style=nil, args={animation: UIStatusBarAnimationSlide})
 
-Set the properties of the application's status bar. Options for style are: `:none`, `:light`, `:dark`, and `:default`. If a screen doesn't call `status_bar` and a `UIStatusBarStyle` is set on the application bundle, then that style will be used. Otherwise, `UIStatusBarStyleDefault` will be used. The animation argument should be a `UIStatusBarAnimation` (or `:none` / `:fade` / `:slide`) and is used to hide or show the status bar when appropriate and defaults to `:slide`. If `status_bar` is set to `false` in the app delegate this will default to hidden as well.
+This method allows you to specify whether or not to show the status bar and whether you want the status bar text to appear light or dark. You may also optionally specify the animation style when hiding/showing the status bar. These settings will only affect the status bar for this screen. Note that if you specify `:light` as the status bar style, and the current screen uses a navigation bar, the bar style must have a dark style in order for the status bar to have white text.
+
+**Style Options:**
+- `:dark` (default)
+- `:light`
+- `:hidden`/`:none`
+
+**Animation Options:**
+- `:fade` (default)
+- `:slide`
+- `:none`
 
 ```ruby
 class MyScreen < PM::Screen
-  status_bar :none, {animation: :fade}
+  status_bar :hidden
   # ...
 end
 
 class MyScreenWithADarkColoredNavBar < PM::Screen
-  status_bar :light
+  status_bar :light, animation: :fade
   # ...
 end
+```
+
+#### hide_status_bar(args={animated: false})
+
+If the status bar is currently displayed, but you want to hide it some time after the screen has already rendered, call `hide_status_bar`. You may optionally specify that the hiding should be animated. This will use the animation style that you already specified (either on the screen or globally on your AppDelegate). If you did not already specify an animation style, the default is `:fade`.
+
+```ruby
+hide_status_bar(animated: true)
+```
+
+#### show_status_bar(args={style: nil, animated: false})
+
+If the status bar is currently hidden and the screen has already rendered, but now you want want to display it, call `show_status_bar`. You may optionally specify the status bar style (light or dark). If you do not specify a style, then the default style that you specified (either on the screen or globally on your AppDelegate) will be used. You may also optionally specify that the showing should be animated. This will use the animation style that you already specified (either on the screen or globally on your AppDelegate). If you did not already specify an animation style, the default is `:fade`.
+
+```ruby
+show_status_bar(style: :light, animated: true)
 ```
 
 #### nav_bar(enabled, nav_bar_options={})

--- a/docs/Reference/ProMotion Screen.md
+++ b/docs/Reference/ProMotion Screen.md
@@ -300,7 +300,7 @@ Runs just before the screen rotates.
 
 #### set_nav_bar_button(side, args = {})
 
-Set a nav bar button. `args` can be `image:`, `title:`, `system_item:`, `button:`, `custom_view:`.
+Set a nav bar button. `args` can be `image:`, `title:` or `system_item:` (not both), `tint_color:`, `button:`, or `custom_view:`.
 
 You can also set arbitrary attributes in the hash and they'll be applied to the button.
 
@@ -318,7 +318,7 @@ set_nav_bar_button :left, {
 ```ruby
 :done,:cancel,:edit,:save,:add,:flexible_space,:fixed_space,:compose,
 :reply,:action,:organize,:bookmarks,:search,:refresh,:stop,:camera,
-:trash,:play,:pause,:rewind,:fast_forward,:undo,:redo,:page_curl
+:trash,:play,:pause,:rewind,:fast_forward,:undo,:redo
 ```
 
 `custom_view` can be any custom `UIView` subclass you initialize yourself

--- a/lib/ProMotion/screen/nav_bar_module.rb
+++ b/lib/ProMotion/screen/nav_bar_module.rb
@@ -75,7 +75,10 @@ module ProMotion
     def bar_button_item(button_type, args)
       return mp("`system_icon:` no longer supported. Use `system_item:` instead.", force_color: :yellow) if args[:system_icon]
       return button_type if button_type.is_a?(UIBarButtonItem)
-      return bar_button_item_system_item(args) if args[:system_item]
+      if args[:system_item]
+        mp("Nav bar button specified both `system_item:` and `title:`. Title will be ignored.", force_color: :yellow) if args[:title]
+        return bar_button_item_system_item(args)
+      end
       return bar_button_item_image(button_type, args) if button_type.is_a?(UIImage)
       return bar_button_item_string(button_type, args) if button_type.is_a?(String)
       return bar_button_item_custom(button_type) if button_type.is_a?(UIView)

--- a/lib/ProMotion/screen/nav_bar_module.rb
+++ b/lib/ProMotion/screen/nav_bar_module.rb
@@ -108,6 +108,7 @@ module ProMotion
     end
 
     def map_bar_button_system_item(symbol)
+      mp("Nav bar button stytem item `:page_curl` has been deprecated.", force_color: :yellow) if symbol == :page_curl
       {
         done:         UIBarButtonSystemItemDone,
         cancel:       UIBarButtonSystemItemCancel,
@@ -132,14 +133,15 @@ module ProMotion
         fast_forward: UIBarButtonSystemItemFastForward,
         undo:         UIBarButtonSystemItemUndo,
         redo:         UIBarButtonSystemItemRedo,
-        page_curl:    UIBarButtonSystemItemPageCurl
+        page_curl:    UIBarButtonSystemItemPageCurl # DEPRECATED
       }[symbol] ||    UIBarButtonSystemItemDone
     end
 
     def map_bar_button_item_style(symbol)
+      mp("Nav bar button style `:bordered` has been deprecated.", force_color: :yellow) if symbol == :bordered
       {
         plain:     UIBarButtonItemStylePlain,
-        bordered:  UIBarButtonItemStyleBordered,
+        bordered:  UIBarButtonItemStyleBordered, # DEPRECATED
         done:      UIBarButtonItemStyleDone
       }[symbol] || UIBarButtonItemStyleDone
     end

--- a/lib/ProMotion/screen/nav_bar_module.rb
+++ b/lib/ProMotion/screen/nav_bar_module.rb
@@ -35,12 +35,6 @@ module ProMotion
       self.navigationItem.setRightBarButtonItems(buttons) if side == :right
     end
 
-    # TODO: In PM 2.1+, entirely remove this deprecated method.
-    def set_nav_bar_left_button(title, args={})
-      mp "set_nav_bar_right_button and set_nav_bar_left_button have been removed. Use set_nav_bar_button :right/:left instead.", force_color: :yellow
-    end
-    alias_method :set_nav_bar_right_button, :set_nav_bar_left_button
-
     def set_toolbar_items(buttons = [], animated = true)
       if buttons
         self.toolbarItems = Array(buttons).map{|b| b.is_a?(UIBarButtonItem) ? b : create_toolbar_button(b) }

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -249,7 +249,7 @@ module ProMotion
     def self.included(base)
       base.extend(ClassMethods)
       base.extend(StatusBarModule::ClassMethods)
-      base.extend(TabClassMethods) # TODO: Is there a better way?
+      base.extend(Tabs::ClassMethods)
     end
   end
 end

--- a/lib/ProMotion/screen/status_bar_module.rb
+++ b/lib/ProMotion/screen/status_bar_module.rb
@@ -1,0 +1,77 @@
+module ProMotion
+  module StatusBarModule
+    def preferredStatusBarStyle
+      styles = {
+        light: UIStatusBarStyleLightContent,
+        dark: UIStatusBarStyleDefault,
+        default: UIStatusBarStyleDefault
+      }
+      styles[self.class.status_bar_style || app.delegate.status_bar_style]  || styles[:default]
+    end
+
+    def preferredStatusBarUpdateAnimation
+      animations = {
+        none: UIStatusBarAnimationNone,
+        fade: UIStatusBarAnimationFade,
+        slide: UIStatusBarAnimationSlide,
+        default: UIStatusBarAnimationFade
+      }
+      animations[self.class.status_bar_animation || app.delegate.status_bar_animation] || animations[:default]
+    end
+
+    def prefersStatusBarHidden
+      style = self.class.status_bar_style || app.delegate.status_bar_style
+      [:none, :hidden].include?(style)
+    end
+
+    def hide_status_bar(opts = {})
+      @previous_status_bar_style = self.class.status_bar_style
+      self.class.status_bar_style(:hidden)
+      update_status_bar_appearance(opts)
+    end
+
+    def show_status_bar(opts = {})
+      new_style = case @previous_status_bar_style
+                  when nil, :hidden, :none
+                    opts[:style] || app.delegate.status_bar_style || :default
+                  else
+                    @previous_status_bar_style
+                  end
+      self.class.status_bar_style(new_style)
+      update_status_bar_appearance(opts)
+    end
+
+    def update_status_bar_appearance(opts = {})
+      if opts[:animated] == true
+        UIView.animateWithDuration(0.3, animations: -> { setNeedsStatusBarAppearanceUpdate })
+      else
+        setNeedsStatusBarAppearanceUpdate
+      end
+    end
+
+    module ClassMethods
+      def status_bar(style = nil, args = {})
+        info_plist_setting = NSBundle.mainBundle.objectForInfoDictionaryKey('UIViewControllerBasedStatusBarAppearance')
+        if info_plist_setting == false
+          mp "The default behavior of `status_bar` has changed. Calling `status_bar` will have no effect until you remove the 'UIViewControllerBasedStatusBarAppearance' setting from info_plist.", force_color: :yellow
+        end
+        @status_bar_style = style
+        @status_bar_animation = args[:animation] if args[:animation]
+      end
+
+      def status_bar_style(val = nil)
+        @status_bar_style = val if val
+        @status_bar_style
+      end
+
+      def status_bar_animation(val = nil)
+        @status_bar_animation = val if val
+        @status_bar_animation
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+  end
+end

--- a/lib/ProMotion/tabs/tabs.rb
+++ b/lib/ProMotion/tabs/tabs.rb
@@ -105,7 +105,7 @@ module ProMotion
       @_tab_symbols[symbol] || symbol
     end
 
-    module TabClassMethods
+    module ClassMethods
       def tab_bar_item(args={})
         @tab_bar_item = args
       end
@@ -116,8 +116,7 @@ module ProMotion
     end
 
     def self.included(base)
-      base.extend(TabClassMethods)
+      base.extend(ClassMethods)
     end
-
   end
 end

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -34,44 +34,6 @@ describe "screen properties" do
     HomeScreen.title.should != 'instance method'
   end
 
-  it "should set the UIStatusBar style to :none" do
-    @screen.class.status_bar :none
-    @screen.view_will_appear(false)
-    UIApplication.sharedApplication.isStatusBarHidden.should == true
-  end
-
-  it "should set the UIStatusBar style to :light" do
-    @screen.class.status_bar :light
-    @screen.view_will_appear(false)
-    UIApplication.sharedApplication.isStatusBarHidden.should == false
-    UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleLightContent
-  end
-
-  it "should set the UIStatusBar style to :dark" do
-    UIApplication.sharedApplication.statusBarStyle = UIStatusBarStyleLightContent
-    @screen.class.status_bar :dark
-    @screen.view_will_appear(false)
-    UIApplication.sharedApplication.isStatusBarHidden.should == false
-    UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleDefault
-  end
-
-  it "should default to a global UIStatusBar style" do
-    NSBundle.mainBundle.mock!(:objectForInfoDictionaryKey) do |key|
-      "UIStatusBarStyleLightContent"
-    end
-    @screen.class.status_bar :default
-    @screen.view_will_appear(false)
-    UIApplication.sharedApplication.isStatusBarHidden.should == false
-    UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleLightContent
-  end
-
-  it "should default to a hidden UIStatusBar if already hidden" do
-    UIApplication.sharedApplication.setStatusBarHidden(true, withAnimation: UIStatusBarAnimationNone)
-    @screen.class.status_bar :default
-    @screen.view_will_appear(false)
-    UIApplication.sharedApplication.isStatusBarHidden.should == true
-  end
-
   it "should set the tab bar item with a system item" do
     @screen.set_tab_bar_item system_item: :contacts
     comparison = UITabBarItem.alloc.initWithTabBarSystemItem(UITabBarSystemItemContacts, tag: 0)


### PR DESCRIPTION
This PR restores functionality for hiding/showing/styling the status bar. In iOS 7, much of the previous functionality was deprecated. I have updated all of the status bar functionality to work with iOS 7+.

In addition, I have also added a few helpful warnings related to nav bar buttons when specifying deprecated options, or incorrectly specifying the title.

Opening this PR now to trigger a Travis build to see if the suite is green.