### PR TITLE
Fixes compilation issues for new versions of rubymotion.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,24 @@
 $:.unshift("/Library/RubyMotion/lib")
 $:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios'
-require 'motion/project/template/gem/gem_tasks'
-require 'bundler'
-Bundler.setup
-Bundler.require(:development)
+require 'bundler/gem_tasks'
+
+begin
+  require 'bundler'
+  Bundler.setup
+  Bundler.require(:development)
+rescue LoadError
+end
+
 require 'ProMotion'
 require 'motion_print'
 
 Motion::Project::App.setup do |app|
   app.name = 'ProMotion'
   app.device_family = [ :ipad ] # so we can test split screen capability
-  app.deployment_target = "8.0"
+  app.deployment_target = '10.0'
   app.redgreen_style = :full # test output
+  app.frameworks << 'QuartzCore'
 end
 
 namespace :spec do


### PR DESCRIPTION
```
$ motion --version
6.3

$ xcodebuild -version
Xcode 11.0
Build version 11A420a
```

I could believe it... i ran `bundle && rake clean:all && rake spec` and all the tests ran and passed! I'm pretty shocked right now... @jamonholmgren all those tests we wrote like 5 years ago and 6 ios version ago still work! ha!